### PR TITLE
Add telemetry module and ingest MeterValues for parity progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository provides a Spring-based scaffold to mirror the Arthexis architec
 - `com.arthexis.platform.ocpp` – OCPP websocket and continuity primitives
 - `com.arthexis.platform.charging` – charging station domain model
 - `com.arthexis.platform.operations` – async/scheduled orchestration
+- `com.arthexis.platform.telemetry` – telemetry ingestion and persistence primitives
 - `com.arthexis.platform.security` – API security policy
 
 ## Quick Start
@@ -46,6 +47,6 @@ OTEL_SDK_DISABLED=false
 ## Next Steps for Arthexis Parity
 
 1. Replace baseline OCPP handler with a standards-compliant adapter (1.6/2.0.1/2.1).
-2. Add dedicated module per business app (billing, users, connectors, telemetry, firmware, etc).
+2. Continue adding dedicated business modules (billing, users, connectors, firmware, etc).
 3. Add admin UI (Jmix/Vaadin) with module-scoped CRUD and command views.
 4. Add WebAuthn4J and TOTP providers to harden operator/admin authentication.

--- a/src/main/java/com/arthexis/platform/ocpp/OcppWebSocketHandler.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppWebSocketHandler.java
@@ -1,6 +1,7 @@
 package com.arthexis.platform.ocpp;
 
 import com.arthexis.platform.charging.ChargingStationService;
+import com.arthexis.platform.telemetry.TelemetryIngestionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Map;
@@ -15,29 +16,42 @@ public class OcppWebSocketHandler extends TextWebSocketHandler {
   private final ObjectMapper objectMapper;
   private final ChargingStationService chargingStationService;
   private final OcppSessionStateStore stateStore;
+  private final TelemetryIngestionService telemetryIngestionService;
 
   public OcppWebSocketHandler(
       ObjectMapper objectMapper,
       ChargingStationService chargingStationService,
-      OcppSessionStateStore stateStore) {
+      OcppSessionStateStore stateStore,
+      TelemetryIngestionService telemetryIngestionService) {
     this.objectMapper = objectMapper;
     this.chargingStationService = chargingStationService;
     this.stateStore = stateStore;
+    this.telemetryIngestionService = telemetryIngestionService;
   }
 
   @Override
   protected void handleTextMessage(WebSocketSession session, TextMessage message) throws IOException {
     OcppMessage incoming = objectMapper.readValue(message.getPayload(), OcppMessage.class);
 
-    if ("Heartbeat".equals(incoming.action()) && incoming.payload() instanceof Map<?, ?> rawPayload) {
+    if (incoming.payload() instanceof Map<?, ?> rawPayload) {
       @SuppressWarnings("unchecked")
       Map<String, Object> payload = (Map<String, Object>) rawPayload;
-      String stationId = (String) payload.getOrDefault("stationId", session.getId());
-      chargingStationService.upsertStatus(stationId, "ONLINE");
-      stateStore.storePendingCommand(stationId, incoming.messageId(), incoming.action());
+
+      if ("Heartbeat".equals(incoming.action())) {
+        String stationId = (String) payload.getOrDefault("stationId", session.getId());
+        chargingStationService.upsertStatus(stationId, "ONLINE");
+        stateStore.storePendingCommand(stationId, incoming.messageId(), incoming.action());
+      }
+
+      if ("MeterValues".equals(incoming.action())) {
+        String stationId = (String) payload.getOrDefault("stationId", session.getId());
+        telemetryIngestionService.ingestMeterValues(stationId, payload);
+      }
     }
 
-    OcppMessage ack = new OcppMessage("CALLRESULT", incoming.messageId(), incoming.action(), Map.of("status", "Accepted"));
+    OcppMessage ack =
+        new OcppMessage(
+            "CALLRESULT", incoming.messageId(), incoming.action(), Map.of("status", "Accepted"));
     session.sendMessage(new TextMessage(objectMapper.writeValueAsString(ack)));
   }
 }

--- a/src/main/java/com/arthexis/platform/telemetry/TelemetryIngestionService.java
+++ b/src/main/java/com/arthexis/platform/telemetry/TelemetryIngestionService.java
@@ -1,0 +1,46 @@
+package com.arthexis.platform.telemetry;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TelemetryIngestionService {
+
+  private final TelemetrySampleRepository repository;
+
+  public TelemetryIngestionService(TelemetrySampleRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional
+  public void ingestMeterValues(String stationId, Map<String, Object> payload) {
+    Instant sampledAt = extractSampledAt(payload);
+
+    payload.entrySet().stream()
+        .filter(entry -> entry.getValue() instanceof Number)
+        .filter(entry -> !"stationId".equals(entry.getKey()))
+        .forEach(
+            entry ->
+                repository.save(
+                    new TelemetrySample(
+                        stationId,
+                        entry.getKey(),
+                        ((Number) entry.getValue()).doubleValue(),
+                        sampledAt)));
+  }
+
+  private Instant extractSampledAt(Map<String, Object> payload) {
+    Object rawSampledAt = payload.get("sampledAt");
+    if (rawSampledAt instanceof String sampledAtText) {
+      try {
+        return Instant.parse(sampledAtText);
+      } catch (DateTimeParseException ignored) {
+        return Instant.now();
+      }
+    }
+    return Instant.now();
+  }
+}

--- a/src/main/java/com/arthexis/platform/telemetry/TelemetrySample.java
+++ b/src/main/java/com/arthexis/platform/telemetry/TelemetrySample.java
@@ -1,0 +1,59 @@
+package com.arthexis.platform.telemetry;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "telemetry_sample")
+public class TelemetrySample {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "station_id", nullable = false, length = 64)
+  private String stationId;
+
+  @Column(name = "metric_name", nullable = false, length = 64)
+  private String metricName;
+
+  @Column(name = "metric_value", nullable = false)
+  private double metricValue;
+
+  @Column(name = "sampled_at", nullable = false)
+  private Instant sampledAt;
+
+  protected TelemetrySample() {}
+
+  public TelemetrySample(String stationId, String metricName, double metricValue, Instant sampledAt) {
+    this.stationId = stationId;
+    this.metricName = metricName;
+    this.metricValue = metricValue;
+    this.sampledAt = sampledAt;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getStationId() {
+    return stationId;
+  }
+
+  public String getMetricName() {
+    return metricName;
+  }
+
+  public double getMetricValue() {
+    return metricValue;
+  }
+
+  public Instant getSampledAt() {
+    return sampledAt;
+  }
+}

--- a/src/main/java/com/arthexis/platform/telemetry/TelemetrySampleRepository.java
+++ b/src/main/java/com/arthexis/platform/telemetry/TelemetrySampleRepository.java
@@ -1,0 +1,5 @@
+package com.arthexis.platform.telemetry;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TelemetrySampleRepository extends JpaRepository<TelemetrySample, Long> {}

--- a/src/main/java/com/arthexis/platform/telemetry/package-info.java
+++ b/src/main/java/com/arthexis/platform/telemetry/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.ApplicationModule(displayName = "Telemetry")
+package com.arthexis.platform.telemetry;

--- a/src/main/resources/db/migration/V2__add_telemetry_samples.sql
+++ b/src/main/resources/db/migration/V2__add_telemetry_samples.sql
@@ -1,0 +1,10 @@
+CREATE TABLE telemetry_sample (
+    id BIGSERIAL PRIMARY KEY,
+    station_id VARCHAR(64) NOT NULL,
+    metric_name VARCHAR(64) NOT NULL,
+    metric_value DOUBLE PRECISION NOT NULL,
+    sampled_at TIMESTAMP WITH TIME ZONE NOT NULL
+);
+
+CREATE INDEX idx_telemetry_station_sampled_at
+    ON telemetry_sample (station_id, sampled_at DESC);

--- a/src/test/java/com/arthexis/platform/telemetry/TelemetryIngestionServiceTests.java
+++ b/src/test/java/com/arthexis/platform/telemetry/TelemetryIngestionServiceTests.java
@@ -1,0 +1,39 @@
+package com.arthexis.platform.telemetry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(TelemetryIngestionService.class)
+class TelemetryIngestionServiceTests {
+
+  @Autowired private TelemetryIngestionService telemetryIngestionService;
+
+  @Autowired private TelemetrySampleRepository telemetrySampleRepository;
+
+  @Test
+  void ingestsNumericMeterValuesAsTelemetrySamples() {
+    telemetryIngestionService.ingestMeterValues(
+        "station-1",
+        Map.of(
+            "stationId", "station-1",
+            "sampledAt", "2026-03-31T00:00:00Z",
+            "powerKw", 18.5,
+            "currentA", 32,
+            "vendorStatus", "charging"));
+
+    var samples = telemetrySampleRepository.findAll();
+
+    assertThat(samples).hasSize(2);
+    assertThat(samples)
+        .extracting(TelemetrySample::getMetricName)
+        .containsExactlyInAnyOrder("powerKw", "currentA");
+    assertThat(samples)
+        .allSatisfy(sample -> assertThat(sample.getStationId()).isEqualTo("station-1"));
+  }
+}


### PR DESCRIPTION
### Motivation
- Add a telemetry ingestion path so OCPP `MeterValues` can be captured as first-class domain data as part of the parity work for the Arthexis Java scaffold. 
- Provide a simple, testable persistence model and ingestion service to enable future analytics, indexing, and business modules.

### Description
- Introduce a new Spring Modulith module `com.arthexis.platform.telemetry` with `TelemetrySample` entity and `TelemetrySampleRepository` JPA interface. 
- Add `TelemetryIngestionService` to parse `MeterValues` payloads, persist numeric metrics, and parse `sampledAt` with a safe fallback to `Instant.now()`. 
- Extend `OcppWebSocketHandler` to route `MeterValues` actions to the telemetry ingestion service while preserving existing heartbeat handling and ACK responses. 
- Add Flyway migration `V2__add_telemetry_samples.sql` to create the `telemetry_sample` table and an index, add a focused `@DataJpaTest` (`TelemetryIngestionServiceTests`), and update `README.md` module list and roadmap wording.

### Testing
- Ran `mvn test -q`, which executed the unit/integration test suite including the new `TelemetryIngestionServiceTests` and succeeded. 
- Observed Flyway apply in tests (migrations v1 and v2 applied) during test startup. 
- Ran `mvn -q spotless:apply` which failed in this environment due to `google-java-format` / JDK incompatibility (`NoSuchMethodError` in the formatter plugin).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb322d99f4832699fd66679407c62d)