### PR TITLE
Add Charger Admin API/CLI and enhance OCPP WebSocket session handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,16 @@ OTEL_SDK_DISABLED=false
 2. Continue adding dedicated business modules (billing, users, connectors, firmware, etc).
 3. Add admin UI (Jmix/Vaadin) with module-scoped CRUD and command views.
 4. Add WebAuthn4J and TOTP providers to harden operator/admin authentication.
+
+## Charger Admin + CLI
+
+The scaffold now includes basic charger administration surfaces:
+
+- **Admin API** (`/api/admin/chargers`)
+  - `GET /api/admin/chargers` list stations
+  - `GET /api/admin/chargers/{stationId}` get one station
+  - `PUT /api/admin/chargers/{stationId}/status` with `{ "status": "ONLINE" }`
+- **CLI hooks** (run alongside the Spring app)
+  - `--charger-cli=list`
+  - `--charger-cli=get --station-id=CP-001`
+  - `--charger-cli=set-status --station-id=CP-001 --status=OFFLINE`

--- a/src/main/java/com/arthexis/platform/charging/ChargingStationAdminController.java
+++ b/src/main/java/com/arthexis/platform/charging/ChargingStationAdminController.java
@@ -1,0 +1,61 @@
+package com.arthexis.platform.charging;
+
+import java.time.Instant;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/chargers")
+public class ChargingStationAdminController {
+
+  private final ChargingStationService chargingStationService;
+
+  public ChargingStationAdminController(ChargingStationService chargingStationService) {
+    this.chargingStationService = chargingStationService;
+  }
+
+  @GetMapping
+  public List<ChargingStationView> listStations() {
+    return chargingStationService.listStations().stream().map(ChargingStationView::from).toList();
+  }
+
+  @GetMapping("/{stationId}")
+  public ChargingStationView getStation(@PathVariable String stationId) {
+    return ChargingStationView.from(chargingStationService.getStation(stationId));
+  }
+
+  @PutMapping("/{stationId}/status")
+  public ChargingStationView updateStatus(
+      @PathVariable String stationId, @RequestBody ChargingStationStatusRequest request) {
+    return ChargingStationView.from(chargingStationService.upsertStatus(stationId, request.status()));
+  }
+
+  @ExceptionHandler(ChargingStationNotFoundException.class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public ApiError stationNotFound(ChargingStationNotFoundException ex) {
+    return new ApiError("charging_station_not_found", ex.getMessage(), Instant.now());
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ApiError badRequest(IllegalArgumentException ex) {
+    return new ApiError("invalid_request", ex.getMessage(), Instant.now());
+  }
+
+  public record ChargingStationView(String stationId, String status, Instant lastSeenAt) {
+
+    private static ChargingStationView from(ChargingStation station) {
+      return new ChargingStationView(station.getStationId(), station.getStatus(), station.getLastSeenAt());
+    }
+  }
+
+  public record ApiError(String code, String message, Instant timestamp) {}
+}

--- a/src/main/java/com/arthexis/platform/charging/ChargingStationCli.java
+++ b/src/main/java/com/arthexis/platform/charging/ChargingStationCli.java
@@ -1,0 +1,63 @@
+package com.arthexis.platform.charging;
+
+import java.util.Arrays;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChargingStationCli implements ApplicationRunner {
+
+  private final ChargingStationService chargingStationService;
+
+  public ChargingStationCli(ChargingStationService chargingStationService) {
+    this.chargingStationService = chargingStationService;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) {
+    if (!args.containsOption("charger-cli")) {
+      return;
+    }
+
+    String command = args.getOptionValues("charger-cli").getFirst();
+    switch (command) {
+      case "list" -> list();
+      case "get" -> get(requiredArg(args, "station-id"));
+      case "set-status" ->
+          setStatus(requiredArg(args, "station-id"), requiredArg(args, "status"));
+      default ->
+          throw new IllegalArgumentException(
+              "Unsupported --charger-cli command. Expected one of: "
+                  + Arrays.asList("list", "get", "set-status"));
+    }
+  }
+
+  private void list() {
+    chargingStationService
+        .listStations()
+        .forEach(
+            station ->
+                System.out.printf(
+                    "%s\t%s\t%s%n",
+                    station.getStationId(), station.getStatus(), station.getLastSeenAt()));
+  }
+
+  private void get(String stationId) {
+    ChargingStation station = chargingStationService.getStation(stationId);
+    System.out.printf("%s\t%s\t%s%n", station.getStationId(), station.getStatus(), station.getLastSeenAt());
+  }
+
+  private void setStatus(String stationId, String status) {
+    ChargingStation station = chargingStationService.upsertStatus(stationId, status);
+    System.out.printf(
+        "updated\t%s\t%s\t%s%n", station.getStationId(), station.getStatus(), station.getLastSeenAt());
+  }
+
+  private String requiredArg(ApplicationArguments args, String key) {
+    if (!args.containsOption(key) || args.getOptionValues(key).isEmpty()) {
+      throw new IllegalArgumentException("Missing required option --" + key);
+    }
+    return args.getOptionValues(key).getFirst();
+  }
+}

--- a/src/main/java/com/arthexis/platform/charging/ChargingStationNotFoundException.java
+++ b/src/main/java/com/arthexis/platform/charging/ChargingStationNotFoundException.java
@@ -1,0 +1,8 @@
+package com.arthexis.platform.charging;
+
+public class ChargingStationNotFoundException extends RuntimeException {
+
+  public ChargingStationNotFoundException(String stationId) {
+    super("Charging station not found: " + stationId);
+  }
+}

--- a/src/main/java/com/arthexis/platform/charging/ChargingStationService.java
+++ b/src/main/java/com/arthexis/platform/charging/ChargingStationService.java
@@ -1,7 +1,9 @@
 package com.arthexis.platform.charging;
 
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 public class ChargingStationService {
@@ -14,9 +16,36 @@ public class ChargingStationService {
 
   @Transactional
   public ChargingStation upsertStatus(String stationId, String status) {
+    String normalizedStatus = normalizeStatus(status);
     ChargingStation station =
-        repository.findByStationId(stationId).orElseGet(() -> new ChargingStation(stationId, status));
-    station.heartbeat(status);
+        repository
+            .findByStationId(stationId)
+            .orElseGet(() -> new ChargingStation(stationId, normalizedStatus));
+    station.heartbeat(normalizedStatus);
     return repository.save(station);
+  }
+
+  @Transactional
+  public ChargingStation markOffline(String stationId) {
+    return upsertStatus(stationId, "OFFLINE");
+  }
+
+  @Transactional(readOnly = true)
+  public List<ChargingStation> listStations() {
+    return repository.findAll();
+  }
+
+  @Transactional(readOnly = true)
+  public ChargingStation getStation(String stationId) {
+    return repository
+        .findByStationId(stationId)
+        .orElseThrow(() -> new ChargingStationNotFoundException(stationId));
+  }
+
+  private String normalizeStatus(String status) {
+    if (!StringUtils.hasText(status)) {
+      throw new IllegalArgumentException("status must be provided");
+    }
+    return status.trim().toUpperCase();
   }
 }

--- a/src/main/java/com/arthexis/platform/charging/ChargingStationStatusRequest.java
+++ b/src/main/java/com/arthexis/platform/charging/ChargingStationStatusRequest.java
@@ -1,0 +1,3 @@
+package com.arthexis.platform.charging;
+
+public record ChargingStationStatusRequest(String status) {}

--- a/src/main/java/com/arthexis/platform/ocpp/OcppSessionStateStore.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppSessionStateStore.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 public class OcppSessionStateStore {
 
   private static final Duration SESSION_TTL = Duration.ofHours(12);
+  private static final String ACTIVE_SESSION_PREFIX = "ocpp:session:";
+  private static final String PENDING_COMMAND_PREFIX = "ocpp:pending:";
   private final StringRedisTemplate redisTemplate;
 
   public OcppSessionStateStore(StringRedisTemplate redisTemplate) {
@@ -15,7 +17,15 @@ public class OcppSessionStateStore {
   }
 
   public void storePendingCommand(String stationId, String commandId, String action) {
-    String key = "ocpp:pending:" + stationId + ":" + commandId;
+    String key = PENDING_COMMAND_PREFIX + stationId + ":" + commandId;
     redisTemplate.opsForValue().set(key, action, SESSION_TTL);
+  }
+
+  public void storeActiveSession(String stationId, String sessionId) {
+    redisTemplate.opsForValue().set(ACTIVE_SESSION_PREFIX + stationId, sessionId, SESSION_TTL);
+  }
+
+  public void removeActiveSession(String stationId) {
+    redisTemplate.delete(ACTIVE_SESSION_PREFIX + stationId);
   }
 }

--- a/src/main/java/com/arthexis/platform/ocpp/OcppWebSocketConfig.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppWebSocketConfig.java
@@ -17,6 +17,8 @@ public class OcppWebSocketConfig implements WebSocketConfigurer {
 
   @Override
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-    registry.addHandler(ocppWebSocketHandler, "/ws/ocpp").setAllowedOriginPatterns("*");
+    registry
+        .addHandler(ocppWebSocketHandler, "/ws/ocpp", "/ws/ocpp/{stationId}")
+        .setAllowedOriginPatterns("*");
   }
 }

--- a/src/main/java/com/arthexis/platform/ocpp/OcppWebSocketHandler.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppWebSocketHandler.java
@@ -4,9 +4,13 @@ import com.arthexis.platform.charging.ChargingStationService;
 import com.arthexis.platform.telemetry.TelemetryIngestionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
@@ -30,6 +34,20 @@ public class OcppWebSocketHandler extends TextWebSocketHandler {
   }
 
   @Override
+  public void afterConnectionEstablished(WebSocketSession session) {
+    String stationId = resolveStationId(session);
+    chargingStationService.upsertStatus(stationId, "ONLINE");
+    stateStore.storeActiveSession(stationId, session.getId());
+  }
+
+  @Override
+  public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+    String stationId = resolveStationId(session);
+    chargingStationService.markOffline(stationId);
+    stateStore.removeActiveSession(stationId);
+  }
+
+  @Override
   protected void handleTextMessage(WebSocketSession session, TextMessage message) throws IOException {
     OcppMessage incoming = objectMapper.readValue(message.getPayload(), OcppMessage.class);
 
@@ -38,13 +56,13 @@ public class OcppWebSocketHandler extends TextWebSocketHandler {
       Map<String, Object> payload = (Map<String, Object>) rawPayload;
 
       if ("Heartbeat".equals(incoming.action())) {
-        String stationId = (String) payload.getOrDefault("stationId", session.getId());
+        String stationId = (String) payload.getOrDefault("stationId", resolveStationId(session));
         chargingStationService.upsertStatus(stationId, "ONLINE");
         stateStore.storePendingCommand(stationId, incoming.messageId(), incoming.action());
       }
 
       if ("MeterValues".equals(incoming.action())) {
-        String stationId = (String) payload.getOrDefault("stationId", session.getId());
+        String stationId = (String) payload.getOrDefault("stationId", resolveStationId(session));
         telemetryIngestionService.ingestMeterValues(stationId, payload);
       }
     }
@@ -53,5 +71,47 @@ public class OcppWebSocketHandler extends TextWebSocketHandler {
         new OcppMessage(
             "CALLRESULT", incoming.messageId(), incoming.action(), Map.of("status", "Accepted"));
     session.sendMessage(new TextMessage(objectMapper.writeValueAsString(ack)));
+  }
+
+  private String resolveStationId(WebSocketSession session) {
+    URI sessionUri = session.getUri();
+    if (sessionUri == null) {
+      return session.getId();
+    }
+
+    String stationIdFromPath = extractFromPath(sessionUri.getPath());
+    if (stationIdFromPath != null) {
+      return stationIdFromPath;
+    }
+
+    String stationIdFromQuery = extractFromQuery(sessionUri.getQuery());
+    if (stationIdFromQuery != null) {
+      return stationIdFromQuery;
+    }
+
+    return session.getId();
+  }
+
+  private String extractFromPath(String path) {
+    if (path == null || !path.startsWith("/ws/ocpp/")) {
+      return null;
+    }
+    String stationId = path.substring("/ws/ocpp/".length()).trim();
+    return stationId.isEmpty() ? null : stationId;
+  }
+
+  private String extractFromQuery(String query) {
+    if (query == null || query.isBlank()) {
+      return null;
+    }
+
+    return Arrays.stream(query.split("&"))
+        .map(entry -> entry.split("=", 2))
+        .filter(parts -> parts.length == 2)
+        .filter(parts -> Objects.equals(parts[0], "chargePointId") || Objects.equals(parts[0], "stationId"))
+        .map(parts -> parts[1])
+        .filter(value -> !value.isBlank())
+        .findFirst()
+        .orElse(null);
   }
 }


### PR DESCRIPTION
### Motivation

- Provide basic charger administration surfaces (HTTP admin API and a CLI) to inspect and control charger station status.
- Improve OCPP websocket session tracking and station identification so station messages and lifecycle events map to station records and Redis state.

### Description

- Added an admin REST controller `ChargingStationAdminController` exposing `/api/admin/chargers` endpoints to list stations, fetch a station, and update station status, plus API error handling types.
- Added a simple CLI runner `ChargingStationCli` supporting `--charger-cli=list`, `--charger-cli=get --station-id=...`, and `--charger-cli=set-status --station-id=... --status=...` to run alongside the Spring app.  
- Extended `ChargingStationService` with `listStations`, `getStation`, `markOffline`, status normalization via `normalizeStatus`, and validation of empty status.  
- Introduced `ChargingStationStatusRequest` record and `ChargingStationNotFoundException` for service/controller flows.  
- Extended OCPP-related components: added active/pending key prefixes in `OcppSessionStateStore` and methods to store/remove active sessions, exposed websocket path with optional `{stationId}` in `OcppWebSocketConfig`, and enhanced `OcppWebSocketHandler` to resolve stationId from path or query, mark stations `ONLINE`/`OFFLINE` on connect/disconnect, store active session ids, and route `Heartbeat`/`MeterValues` messages to the charging and telemetry services.  

### Testing

- Ran the existing Maven test suite with `mvn -DskipTests=false test`, and the suite completed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb3402e0c88326a7725cd168167cdf)