### PR TITLE
Implement OCA-OCPP bridge coverage for 1.6J and 2.x flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ OTEL_SDK_DISABLED=false
 
 ## Next Steps for Arthexis Parity
 
-1. Replace baseline OCPP handler with a standards-compliant adapter (1.6/2.0.1/2.1).
+1. Extend OCA-OCPP coverage beyond the current 1.6J + 2.x baseline (BootNotification, Heartbeat, StatusNotification, MeterValues, TransactionEvent).
 2. Continue adding dedicated business modules (billing, users, connectors, firmware, etc).
 3. Add admin UI (Jmix/Vaadin) with module-scoped CRUD and command views.
 4. Add WebAuthn4J and TOTP providers to harden operator/admin authentication.

--- a/src/main/java/com/arthexis/platform/ocpp/OcaOcppBridgeService.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcaOcppBridgeService.java
@@ -1,0 +1,87 @@
+package com.arthexis.platform.ocpp;
+
+import com.arthexis.platform.charging.ChargingStationService;
+import com.arthexis.platform.telemetry.TelemetryIngestionService;
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OcaOcppBridgeService {
+
+  private final ChargingStationService chargingStationService;
+  private final OcppSessionStateStore stateStore;
+  private final TelemetryIngestionService telemetryIngestionService;
+  private final OcaOcppPayloadNormalizer payloadNormalizer;
+
+  public OcaOcppBridgeService(
+      ChargingStationService chargingStationService,
+      OcppSessionStateStore stateStore,
+      TelemetryIngestionService telemetryIngestionService,
+      OcaOcppPayloadNormalizer payloadNormalizer) {
+    this.chargingStationService = chargingStationService;
+    this.stateStore = stateStore;
+    this.telemetryIngestionService = telemetryIngestionService;
+    this.payloadNormalizer = payloadNormalizer;
+  }
+
+  public Map<String, Object> handleIncoming(String sessionId, OcppMessage incoming) {
+    if (!(incoming.payload() instanceof Map<?, ?> rawPayload)) {
+      return accepted();
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> payload = (Map<String, Object>) rawPayload;
+    String stationId = payloadNormalizer.resolveStationId(sessionId, payload);
+
+    switch (incoming.action()) {
+      case "Heartbeat" -> {
+        chargingStationService.upsertStatus(stationId, "ONLINE");
+        stateStore.storePendingCommand(stationId, incoming.messageId(), incoming.action());
+        return Map.of("currentTime", Instant.now().toString());
+      }
+      case "BootNotification" -> {
+        chargingStationService.upsertStatus(stationId, "ONLINE");
+        stateStore.storePendingCommand(stationId, incoming.messageId(), incoming.action());
+        return Map.of(
+            "status", "Accepted",
+            "currentTime", Instant.now().toString(),
+            "interval", 300);
+      }
+      case "StatusNotification" -> {
+        String status =
+            stringValue(payload.getOrDefault("status", payload.getOrDefault("connectorStatus", "ONLINE")));
+        chargingStationService.upsertStatus(stationId, status);
+        return accepted();
+      }
+      case "MeterValues" -> {
+        telemetryIngestionService.ingestMeterValues(
+            stationId, payloadNormalizer.normalizeMeterValues(stationId, payload));
+        return accepted();
+      }
+      case "TransactionEvent" -> {
+        telemetryIngestionService.ingestMeterValues(
+            stationId, payloadNormalizer.normalizeTransactionEvent(stationId, payload));
+        Object eventType = payload.get("eventType");
+        if ("Started".equals(eventType)) {
+          chargingStationService.upsertStatus(stationId, "CHARGING");
+        }
+        if ("Ended".equals(eventType)) {
+          chargingStationService.upsertStatus(stationId, "AVAILABLE");
+        }
+        return accepted();
+      }
+      default -> {
+        return accepted();
+      }
+    }
+  }
+
+  private String stringValue(Object value) {
+    return value == null ? "" : value.toString();
+  }
+
+  private Map<String, Object> accepted() {
+    return Map.of("status", "Accepted");
+  }
+}

--- a/src/main/java/com/arthexis/platform/ocpp/OcaOcppPayloadNormalizer.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcaOcppPayloadNormalizer.java
@@ -1,0 +1,123 @@
+package com.arthexis.platform.ocpp;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OcaOcppPayloadNormalizer {
+
+  public String resolveStationId(String sessionId, Map<String, Object> payload) {
+    Object explicitStationId = payload.get("stationId");
+    if (explicitStationId instanceof String text && !text.isBlank()) {
+      return text;
+    }
+
+    Object chargingStation = payload.get("chargingStation");
+    if (chargingStation instanceof Map<?, ?> rawChargingStation) {
+      Object serial = rawChargingStation.get("serialNumber");
+      if (serial instanceof String serialText && !serialText.isBlank()) {
+        return serialText;
+      }
+      Object model = rawChargingStation.get("model");
+      if (model instanceof String modelText && !modelText.isBlank()) {
+        return modelText;
+      }
+    }
+
+    return sessionId;
+  }
+
+  public Map<String, Object> normalizeMeterValues(String stationId, Map<String, Object> payload) {
+    Map<String, Object> normalized = new LinkedHashMap<>();
+    normalized.put("stationId", stationId);
+    normalized.putAll(extractSampledValues(payload));
+    if (!normalized.containsKey("sampledAt")) {
+      normalized.put("sampledAt", Instant.now().toString());
+    }
+    return normalized;
+  }
+
+  public Map<String, Object> normalizeTransactionEvent(String stationId, Map<String, Object> payload) {
+    Map<String, Object> normalized = new LinkedHashMap<>();
+    normalized.put("stationId", stationId);
+
+    Object timestamp = payload.get("timestamp");
+    if (timestamp instanceof String text) {
+      normalized.put("sampledAt", text);
+    }
+
+    Object totalCost = payload.get("totalCost");
+    if (totalCost instanceof Number number) {
+      normalized.put("totalCost", number);
+    }
+
+    normalized.putAll(extractSampledValues(payload));
+    if (!normalized.containsKey("sampledAt")) {
+      normalized.put("sampledAt", Instant.now().toString());
+    }
+    return normalized;
+  }
+
+  private Map<String, Object> extractSampledValues(Map<String, Object> payload) {
+    Map<String, Object> flattened = new LinkedHashMap<>();
+    List<Map<String, Object>> meterValues = asObjectMapList(payload.get("meterValue"));
+    if (meterValues.isEmpty()) {
+      meterValues = asObjectMapList(payload.get("meterValues"));
+    }
+
+    for (Map<String, Object> meterValue : meterValues) {
+      Object timestamp = meterValue.get("timestamp");
+      if (timestamp instanceof String text) {
+        flattened.putIfAbsent("sampledAt", text);
+      }
+
+      for (Map<String, Object> sampledValue : asObjectMapList(meterValue.get("sampledValue"))) {
+        String metricName = stringValue(sampledValue.getOrDefault("measurand", "meter.value"));
+        Object rawValue = sampledValue.get("value");
+        Double numericValue = parseNumeric(rawValue);
+        if (numericValue != null) {
+          flattened.put(metricName, numericValue);
+        }
+      }
+    }
+
+    return flattened;
+  }
+
+  private List<Map<String, Object>> asObjectMapList(Object raw) {
+    if (!(raw instanceof List<?> list)) {
+      return List.of();
+    }
+    List<Map<String, Object>> result = new ArrayList<>();
+    for (Object item : list) {
+      if (item instanceof Map<?, ?> map) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> typed = (Map<String, Object>) map;
+        result.add(typed);
+      }
+    }
+    return result;
+  }
+
+  private Double parseNumeric(Object rawValue) {
+    if (rawValue instanceof Number number) {
+      return number.doubleValue();
+    }
+    if (rawValue instanceof String text) {
+      try {
+        return Double.parseDouble(text);
+      } catch (NumberFormatException ignored) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private String stringValue(Object value) {
+    return value == null ? "" : value.toString();
+  }
+}

--- a/src/main/java/com/arthexis/platform/ocpp/OcppWebSocketHandler.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppWebSocketHandler.java
@@ -1,10 +1,7 @@
 package com.arthexis.platform.ocpp;
 
-import com.arthexis.platform.charging.ChargingStationService;
-import com.arthexis.platform.telemetry.TelemetryIngestionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.util.Map;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -14,44 +11,22 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 public class OcppWebSocketHandler extends TextWebSocketHandler {
 
   private final ObjectMapper objectMapper;
-  private final ChargingStationService chargingStationService;
-  private final OcppSessionStateStore stateStore;
-  private final TelemetryIngestionService telemetryIngestionService;
+  private final OcaOcppBridgeService ocaOcppBridgeService;
 
-  public OcppWebSocketHandler(
-      ObjectMapper objectMapper,
-      ChargingStationService chargingStationService,
-      OcppSessionStateStore stateStore,
-      TelemetryIngestionService telemetryIngestionService) {
+  public OcppWebSocketHandler(ObjectMapper objectMapper, OcaOcppBridgeService ocaOcppBridgeService) {
     this.objectMapper = objectMapper;
-    this.chargingStationService = chargingStationService;
-    this.stateStore = stateStore;
-    this.telemetryIngestionService = telemetryIngestionService;
+    this.ocaOcppBridgeService = ocaOcppBridgeService;
   }
 
   @Override
   protected void handleTextMessage(WebSocketSession session, TextMessage message) throws IOException {
     OcppMessage incoming = objectMapper.readValue(message.getPayload(), OcppMessage.class);
-
-    if (incoming.payload() instanceof Map<?, ?> rawPayload) {
-      @SuppressWarnings("unchecked")
-      Map<String, Object> payload = (Map<String, Object>) rawPayload;
-
-      if ("Heartbeat".equals(incoming.action())) {
-        String stationId = (String) payload.getOrDefault("stationId", session.getId());
-        chargingStationService.upsertStatus(stationId, "ONLINE");
-        stateStore.storePendingCommand(stationId, incoming.messageId(), incoming.action());
-      }
-
-      if ("MeterValues".equals(incoming.action())) {
-        String stationId = (String) payload.getOrDefault("stationId", session.getId());
-        telemetryIngestionService.ingestMeterValues(stationId, payload);
-      }
-    }
-
     OcppMessage ack =
         new OcppMessage(
-            "CALLRESULT", incoming.messageId(), incoming.action(), Map.of("status", "Accepted"));
+            "CALLRESULT",
+            incoming.messageId(),
+            incoming.action(),
+            ocaOcppBridgeService.handleIncoming(session.getId(), incoming));
     session.sendMessage(new TextMessage(objectMapper.writeValueAsString(ack)));
   }
 }

--- a/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeServiceTests.java
+++ b/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeServiceTests.java
@@ -1,0 +1,73 @@
+package com.arthexis.platform.ocpp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OcaOcppBridgeServiceTests {
+
+  private OcaOcppPayloadNormalizer normalizer;
+
+  @BeforeEach
+  void setUp() {
+    normalizer = new OcaOcppPayloadNormalizer();
+  }
+
+  @Test
+  void resolvesOcpp16StationIdentifierFromStationId() {
+    String stationId = normalizer.resolveStationId("session-1", Map.of("stationId", "CP-16"));
+
+    assertThat(stationId).isEqualTo("CP-16");
+  }
+
+  @Test
+  void flattensOcpp16MeterValuesIntoTelemetryMetrics() {
+    Map<String, Object> normalizedPayload =
+        normalizer.normalizeMeterValues(
+            "CP-16",
+            Map.of(
+                "meterValue",
+                List.of(
+                    Map.of(
+                        "timestamp",
+                        "2026-03-31T00:00:00Z",
+                        "sampledValue",
+                        List.of(
+                            Map.of("measurand", "Power.Active.Import", "value", "7.50"),
+                            Map.of("measurand", "Current.Import", "value", 32))))));
+
+    assertThat(normalizedPayload).containsEntry("stationId", "CP-16");
+    assertThat(normalizedPayload).containsEntry("Power.Active.Import", 7.5d);
+    assertThat(normalizedPayload).containsEntry("Current.Import", 32d);
+    assertThat(normalizedPayload).containsEntry("sampledAt", "2026-03-31T00:00:00Z");
+  }
+
+  @Test
+  void supportsOcpp2xTransactionEventUsingChargingStationBlock() {
+    String stationId =
+        normalizer.resolveStationId(
+            "session-3", Map.of("chargingStation", Map.of("serialNumber", "CP-2X", "model", "AX-50")));
+
+    Map<String, Object> normalizedPayload =
+        normalizer.normalizeTransactionEvent(
+            stationId,
+            Map.of(
+                "eventType",
+                "Started",
+                "timestamp",
+                "2026-03-31T01:00:00Z",
+                "meterValue",
+                List.of(
+                    Map.of(
+                        "sampledValue",
+                        List.of(Map.of("measurand", "Energy.Active.Import.Register", "value", "12.3"))))));
+
+    assertThat(stationId).isEqualTo("CP-2X");
+    assertThat(normalizedPayload).containsEntry("stationId", "CP-2X");
+    assertThat(normalizedPayload).containsEntry("Energy.Active.Import.Register", 12.3d);
+    assertThat(normalizedPayload).containsEntry("sampledAt", "2026-03-31T01:00:00Z");
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a focused OCA-oriented adapter layer to cover OCPP 1.6J and 2.x message shapes Arthexis previously handled ad-hoc (BootNotification, Heartbeat, StatusNotification, MeterValues, TransactionEvent). 
- Centralize station-state updates and telemetry normalization so the websocket handler only delegates and the domain services receive consistent payloads.

### Description
- Add `OcaOcppBridgeService` to orchestrate OCPP actions and map them to charging station state updates and telemetry ingestion. 
- Add `OcaOcppPayloadNormalizer` to normalize 1.6J and 2.x payload shapes (station resolution, flattened sampled meter values, transaction event normalization). 
- Update `OcppWebSocketHandler` to delegate message processing to the new bridge service and return the bridge-produced CALLRESULT payload. 
- Add unit tests (`OcaOcppBridgeServiceTests`) that validate station-id resolution and meter/transaction flattening for both 1.6J and 2.x payloads. 
- Update `README.md` parity roadmap to reflect the new baseline coverage.

### Testing
- Running the full suite with `mvn test` failed due to environment/tooling issues (scheduled task attempted RabbitMQ connection and Mockito inline-mock limitation produced 3 test errors). 
- Targeted unit tests with `mvn -q -Dtest=OcaOcppBridgeServiceTests,TelemetryIngestionServiceTests test` completed successfully. 
- A compile-only verification `mvn -q -DskipTests compile` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb3894a8bc8326af8e7410303a7813)