### PR TITLE
Add connector-level OCPP state tracking and deterministic station rollups

### DIFF
--- a/src/main/java/com/arthexis/platform/charging/ChargingConnectorState.java
+++ b/src/main/java/com/arthexis/platform/charging/ChargingConnectorState.java
@@ -1,0 +1,139 @@
+package com.arthexis.platform.charging;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+
+@Entity
+@Table(
+    name = "charging_connector_state",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_connector_state_station_evse_connector",
+          columnNames = {"station_id", "evse_id", "connector_id"})
+    })
+public class ChargingConnectorState {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "station_id", length = 64, nullable = false)
+  private String stationId;
+
+  @Column(name = "evse_id", nullable = false)
+  private int evseId;
+
+  @Column(name = "connector_id", nullable = false)
+  private int connectorId;
+
+  @Column(name = "connector_status", length = 32, nullable = false)
+  private String connectorStatus;
+
+  @Column(name = "connector_type", length = 64)
+  private String connectorType;
+
+  @Column(name = "availability", length = 32)
+  private String availability;
+
+  @Column(name = "last_status_at", nullable = false)
+  private Instant lastStatusAt;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  protected ChargingConnectorState() {}
+
+  public ChargingConnectorState(
+      String stationId,
+      int evseId,
+      int connectorId,
+      String connectorStatus,
+      String connectorType,
+      String availability,
+      Instant lastStatusAt) {
+    this.stationId = stationId;
+    this.evseId = evseId;
+    this.connectorId = connectorId;
+    this.connectorStatus = connectorStatus;
+    this.connectorType = connectorType;
+    this.availability = availability;
+    this.lastStatusAt = lastStatusAt;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getStationId() {
+    return stationId;
+  }
+
+  public int getEvseId() {
+    return evseId;
+  }
+
+  public int getConnectorId() {
+    return connectorId;
+  }
+
+  public String getConnectorStatus() {
+    return connectorStatus;
+  }
+
+  public String getConnectorType() {
+    return connectorType;
+  }
+
+  public String getAvailability() {
+    return availability;
+  }
+
+  public Instant getLastStatusAt() {
+    return lastStatusAt;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void updateState(String status, String type, String newAvailability, Instant reportedAt) {
+    this.connectorStatus = status;
+    this.connectorType = type;
+    this.availability = newAvailability;
+    this.lastStatusAt = reportedAt;
+  }
+
+  @PrePersist
+  void onCreate() {
+    Instant now = Instant.now();
+    if (createdAt == null) {
+      createdAt = now;
+    }
+    if (updatedAt == null) {
+      updatedAt = now;
+    }
+    if (lastStatusAt == null) {
+      lastStatusAt = now;
+    }
+  }
+
+  @PreUpdate
+  void onUpdate() {
+    updatedAt = Instant.now();
+  }
+}

--- a/src/main/java/com/arthexis/platform/charging/ChargingConnectorStateRepository.java
+++ b/src/main/java/com/arthexis/platform/charging/ChargingConnectorStateRepository.java
@@ -1,0 +1,13 @@
+package com.arthexis.platform.charging;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChargingConnectorStateRepository extends JpaRepository<ChargingConnectorState, Long> {
+
+  Optional<ChargingConnectorState> findByStationIdAndEvseIdAndConnectorId(
+      String stationId, int evseId, int connectorId);
+
+  List<ChargingConnectorState> findByStationIdOrderByEvseIdAscConnectorIdAsc(String stationId);
+}

--- a/src/main/java/com/arthexis/platform/charging/ChargingConnectorStateService.java
+++ b/src/main/java/com/arthexis/platform/charging/ChargingConnectorStateService.java
@@ -1,0 +1,129 @@
+package com.arthexis.platform.charging;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ChargingConnectorStateService {
+
+  private static final List<String> STATION_STATUS_PRECEDENCE =
+      List.of(
+          "FAULTED",
+          "UNAVAILABLE",
+          "CHARGING",
+          "SUSPENDED_EVSE",
+          "SUSPENDED_EV",
+          "PREPARING",
+          "FINISHING",
+          "RESERVED",
+          "OCCUPIED",
+          "AVAILABLE",
+          "ONLINE",
+          "UNKNOWN");
+
+  private static final Map<String, String> OCPP_STATUS_TO_STATION_STATUS =
+      Map.ofEntries(
+          Map.entry("FAULTED", "FAULTED"),
+          Map.entry("UNAVAILABLE", "UNAVAILABLE"),
+          Map.entry("CHARGING", "CHARGING"),
+          Map.entry("SUSPENDED_EVSE", "SUSPENDED_EVSE"),
+          Map.entry("SUSPENDED_EV", "SUSPENDED_EV"),
+          Map.entry("PREPARING", "PREPARING"),
+          Map.entry("FINISHING", "FINISHING"),
+          Map.entry("RESERVED", "RESERVED"),
+          Map.entry("OCCUPIED", "OCCUPIED"),
+          Map.entry("AVAILABLE", "AVAILABLE"),
+          Map.entry("UNKNOWN", "UNKNOWN"));
+
+  private final ChargingConnectorStateRepository repository;
+
+  public ChargingConnectorStateService(ChargingConnectorStateRepository repository) {
+    this.repository = repository;
+  }
+
+  @Transactional
+  public ChargingConnectorState upsertConnectorState(
+      String stationId,
+      int evseId,
+      int connectorId,
+      String connectorStatus,
+      String connectorType,
+      String availability,
+      Instant reportedAt) {
+    String normalizedStatus = normalizeStatus(connectorStatus);
+    String normalizedAvailability = normalizeOptional(availability);
+    String normalizedConnectorType = normalizeOptional(connectorType);
+    Instant timestamp = reportedAt == null ? Instant.now() : reportedAt;
+
+    ChargingConnectorState connectorState =
+        repository
+            .findByStationIdAndEvseIdAndConnectorId(stationId, evseId, connectorId)
+            .orElseGet(
+                () ->
+                    new ChargingConnectorState(
+                        stationId,
+                        evseId,
+                        connectorId,
+                        normalizedStatus,
+                        normalizedConnectorType,
+                        normalizedAvailability,
+                        timestamp));
+
+    connectorState.updateState(
+        normalizedStatus, normalizedConnectorType, normalizedAvailability, timestamp);
+    return repository.save(connectorState);
+  }
+
+  @Transactional(readOnly = true)
+  public String deriveStationAggregateStatus(String stationId, String fallbackStatus) {
+    List<ChargingConnectorState> connectors = repository.findByStationIdOrderByEvseIdAscConnectorIdAsc(stationId);
+    if (connectors.isEmpty()) {
+      return normalizeFallbackStatus(fallbackStatus);
+    }
+
+    String winningStatus = "UNKNOWN";
+    int winningRank = STATION_STATUS_PRECEDENCE.size();
+
+    for (ChargingConnectorState connector : connectors) {
+      String candidate = toStationStatus(connector.getConnectorStatus());
+      int rank = rank(candidate);
+      if (rank < winningRank) {
+        winningStatus = candidate;
+        winningRank = rank;
+      }
+    }
+
+    return winningStatus;
+  }
+
+  private String normalizeStatus(String status) {
+    String normalized = normalizeOptional(status);
+    return normalized == null ? "UNKNOWN" : normalized;
+  }
+
+  private String normalizeFallbackStatus(String fallbackStatus) {
+    String normalized = normalizeOptional(fallbackStatus);
+    return normalized == null ? "ONLINE" : normalized;
+  }
+
+  private String normalizeOptional(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    String trimmed = value.trim().replace('-', '_').replace(' ', '_');
+    String snakeLike = trimmed.replaceAll("([a-z0-9])([A-Z])", "$1_$2");
+    return snakeLike.toUpperCase();
+  }
+
+  private String toStationStatus(String connectorStatus) {
+    return OCPP_STATUS_TO_STATION_STATUS.getOrDefault(connectorStatus, connectorStatus);
+  }
+
+  private int rank(String status) {
+    int index = STATION_STATUS_PRECEDENCE.indexOf(status);
+    return index >= 0 ? index : STATION_STATUS_PRECEDENCE.size() - 1;
+  }
+}

--- a/src/main/java/com/arthexis/platform/ocpp/OcaOcppBridgeService.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcaOcppBridgeService.java
@@ -1,5 +1,6 @@
 package com.arthexis.platform.ocpp;
 
+import com.arthexis.platform.charging.ChargingConnectorStateService;
 import com.arthexis.platform.charging.ChargingStationAdminDetails;
 import com.arthexis.platform.charging.ChargingStationService;
 import com.arthexis.platform.telemetry.TelemetryIngestionService;
@@ -11,16 +12,19 @@ import org.springframework.stereotype.Service;
 public class OcaOcppBridgeService {
 
   private final ChargingStationService chargingStationService;
+  private final ChargingConnectorStateService connectorStateService;
   private final OcppSessionStateStore stateStore;
   private final TelemetryIngestionService telemetryIngestionService;
   private final OcaOcppPayloadNormalizer payloadNormalizer;
 
   public OcaOcppBridgeService(
       ChargingStationService chargingStationService,
+      ChargingConnectorStateService connectorStateService,
       OcppSessionStateStore stateStore,
       TelemetryIngestionService telemetryIngestionService,
       OcaOcppPayloadNormalizer payloadNormalizer) {
     this.chargingStationService = chargingStationService;
+    this.connectorStateService = connectorStateService;
     this.stateStore = stateStore;
     this.telemetryIngestionService = telemetryIngestionService;
     this.payloadNormalizer = payloadNormalizer;
@@ -52,9 +56,23 @@ public class OcaOcppBridgeService {
             "interval", 300);
       }
       case "StatusNotification" -> {
-        String status =
-            stringValue(payload.getOrDefault("status", payload.getOrDefault("connectorStatus", "ONLINE")));
-        chargingStationService.upsertStatus(stationId, status, buildAdminDetails(payload, false));
+        String connectorStatus =
+            stringValue(
+                payload.getOrDefault("status", payload.getOrDefault("connectorStatus", "UNKNOWN")));
+        int evseId = resolveEvseId(payload);
+        int connectorId = resolveConnectorId(payload);
+        connectorStateService.upsertConnectorState(
+            stationId,
+            evseId,
+            connectorId,
+            connectorStatus,
+            stringValue(payload.get("connectorType")),
+            stringValue(payload.getOrDefault("availability", payload.get("connectorAvailability"))),
+            Instant.now());
+
+        String aggregateStatus =
+            connectorStateService.deriveStationAggregateStatus(stationId, connectorStatus);
+        chargingStationService.upsertStatus(stationId, aggregateStatus, buildAdminDetails(payload, false));
         return accepted();
       }
       case "MeterValues" -> {
@@ -81,6 +99,22 @@ public class OcaOcppBridgeService {
   }
 
 
+  private int resolveEvseId(Map<String, Object> payload) {
+    Map<String, Object> evse = mapValue(payload.get("evse"));
+    Object evseId = evse.getOrDefault("id", payload.getOrDefault("evseId", 1));
+    return intValue(evseId, 1);
+  }
+
+  private int resolveConnectorId(Map<String, Object> payload) {
+    Map<String, Object> evse = mapValue(payload.get("evse"));
+    Object connectorId =
+        firstNonNull(
+            evse.get("connectorId"),
+            payload.get("connectorId"),
+            payload.get("connector"),
+            1);
+    return intValue(connectorId, 1);
+  }
 
   private ChargingStationAdminDetails buildAdminDetails(
       Map<String, Object> payload, boolean includeBootTime) {
@@ -159,6 +193,30 @@ public class OcaOcppBridgeService {
   }
   private String stringValue(Object value) {
     return value == null ? "" : value.toString();
+  }
+
+
+  private Object firstNonNull(Object... values) {
+    for (Object value : values) {
+      if (value != null) {
+        return value;
+      }
+    }
+    return null;
+  }
+
+  private int intValue(Object value, int defaultValue) {
+    if (value instanceof Number number) {
+      return number.intValue();
+    }
+    if (value == null) {
+      return defaultValue;
+    }
+    try {
+      return Integer.parseInt(value.toString());
+    } catch (NumberFormatException ex) {
+      return defaultValue;
+    }
   }
 
   private Map<String, Object> accepted() {

--- a/src/main/resources/db/migration/V4__add_connector_state.sql
+++ b/src/main/resources/db/migration/V4__add_connector_state.sql
@@ -1,0 +1,17 @@
+CREATE TABLE charging_connector_state (
+    id BIGSERIAL PRIMARY KEY,
+    station_id VARCHAR(64) NOT NULL,
+    evse_id INTEGER NOT NULL,
+    connector_id INTEGER NOT NULL,
+    connector_status VARCHAR(32) NOT NULL,
+    connector_type VARCHAR(64),
+    availability VARCHAR(32),
+    last_status_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_connector_state_station_evse_connector
+        UNIQUE (station_id, evse_id, connector_id)
+);
+
+CREATE INDEX idx_connector_state_station ON charging_connector_state(station_id);
+CREATE INDEX idx_connector_state_station_status ON charging_connector_state(station_id, connector_status);

--- a/src/test/java/com/arthexis/platform/charging/ChargingConnectorStateServiceTests.java
+++ b/src/test/java/com/arthexis/platform/charging/ChargingConnectorStateServiceTests.java
@@ -1,0 +1,63 @@
+package com.arthexis.platform.charging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChargingConnectorStateServiceTests {
+
+  @Mock private ChargingConnectorStateRepository repository;
+
+  private ChargingConnectorStateService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new ChargingConnectorStateService(repository);
+  }
+
+  @Test
+  void derivesStationStatusUsingDeterministicPrecedence() {
+    when(repository.findByStationIdOrderByEvseIdAscConnectorIdAsc("CP-1"))
+        .thenReturn(
+            List.of(
+                new ChargingConnectorState("CP-1", 1, 1, "AVAILABLE", "TYPE2", "OPERATIVE", null),
+                new ChargingConnectorState("CP-1", 1, 2, "CHARGING", "CCS2", "OPERATIVE", null),
+                new ChargingConnectorState("CP-1", 2, 1, "FAULTED", "CCS2", "INOPERATIVE", null)));
+
+    String aggregate = service.deriveStationAggregateStatus("CP-1", "ONLINE");
+
+    assertThat(aggregate).isEqualTo("FAULTED");
+  }
+
+  @Test
+  void usesFallbackWhenNoConnectorStateExists() {
+    when(repository.findByStationIdOrderByEvseIdAscConnectorIdAsc("CP-2")).thenReturn(List.of());
+
+    String aggregate = service.deriveStationAggregateStatus("CP-2", "available");
+
+    assertThat(aggregate).isEqualTo("AVAILABLE");
+  }
+
+  @Test
+  void upsertNormalizesConnectorFields() {
+    when(repository.findByStationIdAndEvseIdAndConnectorId("CP-3", 1, 3)).thenReturn(Optional.empty());
+    when(repository.save(any(ChargingConnectorState.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    ChargingConnectorState connectorState =
+        service.upsertConnectorState("CP-3", 1, 3, "SuspendedEvse", "iec 62196-2", "operative", null);
+
+    assertThat(connectorState.getConnectorStatus()).isEqualTo("SUSPENDED_EVSE");
+    assertThat(connectorState.getConnectorType()).isEqualTo("IEC_62196_2");
+    assertThat(connectorState.getAvailability()).isEqualTo("OPERATIVE");
+    assertThat(connectorState.getLastStatusAt()).isNotNull();
+  }
+}

--- a/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeStatusNotificationTests.java
+++ b/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeStatusNotificationTests.java
@@ -1,0 +1,122 @@
+package com.arthexis.platform.ocpp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.arthexis.platform.charging.ChargingConnectorState;
+import com.arthexis.platform.charging.ChargingConnectorStateRepository;
+import com.arthexis.platform.charging.ChargingConnectorStateService;
+import com.arthexis.platform.charging.ChargingStation;
+import com.arthexis.platform.charging.ChargingStationRepository;
+import com.arthexis.platform.charging.ChargingStationService;
+import com.arthexis.platform.telemetry.TelemetryIngestionService;
+import com.arthexis.platform.telemetry.TelemetrySampleRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class OcaOcppBridgeStatusNotificationTests {
+
+  @Mock private ChargingStationRepository chargingStationRepository;
+  @Mock private ChargingConnectorStateRepository connectorStateRepository;
+  @Mock private TelemetrySampleRepository telemetrySampleRepository;
+
+  private OcaOcppBridgeService bridgeService;
+
+  @BeforeEach
+  void setUp() {
+    bridgeService =
+        new OcaOcppBridgeService(
+            new ChargingStationService(chargingStationRepository),
+            new ChargingConnectorStateService(connectorStateRepository),
+            new OcppSessionStateStore(new StringRedisTemplate()),
+            new TelemetryIngestionService(telemetrySampleRepository),
+            new OcaOcppPayloadNormalizer());
+  }
+
+  @Test
+  void mapsStatusNotificationToConnectorStateAndStationAggregateStatus() {
+    when(connectorStateRepository.findByStationIdAndEvseIdAndConnectorId("CP-16", 1, 2))
+        .thenReturn(Optional.empty());
+    when(connectorStateRepository.save(any(ChargingConnectorState.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(connectorStateRepository.findByStationIdOrderByEvseIdAscConnectorIdAsc("CP-16"))
+        .thenReturn(List.of(new ChargingConnectorState("CP-16", 1, 2, "CHARGING", "CCS2", "OPERATIVE", null)));
+
+    when(chargingStationRepository.findByStationId("CP-16")).thenReturn(Optional.empty());
+    when(chargingStationRepository.save(any(ChargingStation.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    OcppMessage incoming =
+        new OcppMessage(
+            "2",
+            "msg-1",
+            "StatusNotification",
+            Map.of(
+                "stationId", "CP-16",
+                "status", "Charging",
+                "connectorId", 2,
+                "connectorType", "CCS2",
+                "availability", "Operative"));
+
+    Map<String, Object> response = bridgeService.handleIncoming("session-1", incoming);
+
+    assertThat(response).containsEntry("status", "Accepted");
+
+    ArgumentCaptor<ChargingStation> stationCaptor = ArgumentCaptor.forClass(ChargingStation.class);
+    verify(chargingStationRepository).save(stationCaptor.capture());
+    assertThat(stationCaptor.getValue().getStationId()).isEqualTo("CP-16");
+    assertThat(stationCaptor.getValue().getStatus()).isEqualTo("CHARGING");
+
+    ArgumentCaptor<ChargingConnectorState> connectorCaptor =
+        ArgumentCaptor.forClass(ChargingConnectorState.class);
+    verify(connectorStateRepository).save(connectorCaptor.capture());
+    assertThat(connectorCaptor.getValue().getEvseId()).isEqualTo(1);
+    assertThat(connectorCaptor.getValue().getConnectorId()).isEqualTo(2);
+    assertThat(connectorCaptor.getValue().getConnectorStatus()).isEqualTo("CHARGING");
+  }
+
+  @Test
+  void readsOcpp2xEvseBlockForConnectorIdentifiers() {
+    when(connectorStateRepository.findByStationIdAndEvseIdAndConnectorId("CP-2X", 4, 7))
+        .thenReturn(Optional.empty());
+    when(connectorStateRepository.save(any(ChargingConnectorState.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(connectorStateRepository.findByStationIdOrderByEvseIdAscConnectorIdAsc("CP-2X"))
+        .thenReturn(List.of(new ChargingConnectorState("CP-2X", 4, 7, "AVAILABLE", null, "OPERATIVE", null)));
+
+    when(chargingStationRepository.findByStationId("CP-2X")).thenReturn(Optional.empty());
+    when(chargingStationRepository.save(any(ChargingStation.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    OcppMessage incoming =
+        new OcppMessage(
+            "2",
+            "msg-2",
+            "StatusNotification",
+            Map.of(
+                "chargingStation", Map.of("serialNumber", "CP-2X"),
+                "connectorStatus", "Available",
+                "evse", Map.of("id", 4, "connectorId", 7),
+                "connectorAvailability", "Operative"));
+
+    bridgeService.handleIncoming("session-2", incoming);
+
+    ArgumentCaptor<ChargingConnectorState> connectorCaptor =
+        ArgumentCaptor.forClass(ChargingConnectorState.class);
+    verify(connectorStateRepository).save(connectorCaptor.capture());
+    assertThat(connectorCaptor.getValue().getStationId()).isEqualTo("CP-2X");
+    assertThat(connectorCaptor.getValue().getEvseId()).isEqualTo(4);
+    assertThat(connectorCaptor.getValue().getConnectorId()).isEqualTo(7);
+  }
+}


### PR DESCRIPTION
### Motivation
- Introduce connector/EVSE-level state so OCPP `StatusNotification` events can be recorded per connector rather than only at station level.
- Map OCPP status fields to connector updates while keeping existing station-level status semantics via an aggregate rollup.
- Provide deterministic precedence rules to derive a single station status from multiple connector states.

### Description
- Add a JPA entity `ChargingConnectorState` and Flyway migration `V4__add_connector_state.sql` to persist per-connector state (stationId, evseId, connectorId, connectorStatus, connectorType, availability, timestamps) and indexes/unique constraint.
- Add `ChargingConnectorStateRepository` with lookups for `findByStationIdAndEvseIdAndConnectorId` and `findByStationIdOrderByEvseIdAscConnectorIdAsc` used by rollups.
- Implement `ChargingConnectorStateService` to upsert/normalize connector fields, map OCPP statuses to station-level statuses, and derive station aggregate status using a deterministic precedence list (`FAULTED`, `UNAVAILABLE`, `CHARGING`, …, `ONLINE`, `UNKNOWN`).
- Update `OcaOcppBridgeService` to handle `StatusNotification` by resolving EVSE/connector identifiers (supports OCPP 1.6 and 2.x shapes), writing connector-level state, deriving the station aggregate via the new service, and then persisting the station-level status (preserving existing station workflows).
- Add unit tests covering connector normalization and precedence (`ChargingConnectorStateServiceTests`) and bridge mapping from `StatusNotification` to connector upsert + station aggregate (`OcaOcppBridgeStatusNotificationTests`).

### Testing
- Ran `mvn -q -DskipTests compile` to ensure the codebase compiles after changes (succeeded).
- Ran targeted unit tests with `mvn -q -Dtest=ChargingConnectorStateServiceTests,ChargingStationServiceTests,OcaOcppBridgeServiceTests,OcaOcppBridgeStatusNotificationTests test` and they passed (succeeded).
- An earlier `mvn test` run showed Mockito/ByteBuddy instrumentation errors on this environment (Java/ByteBuddy compatibility), which was addressed by adjusting test wiring and running the targeted tests above (initial full run failed, targeted tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbfe0d92688326901aa906d8a14f59)