### PR TITLE
Add OCPP session/message audit persistence and websocket recording

### DIFF
--- a/src/main/java/com/arthexis/platform/ocpp/OcaOcppBridgeService.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcaOcppBridgeService.java
@@ -30,35 +30,31 @@ public class OcaOcppBridgeService {
     this.payloadNormalizer = payloadNormalizer;
   }
 
-  public Map<String, Object> handleIncoming(String sessionId, OcppMessage incoming) {
+  public OcppBridgeResponse handleIncoming(String sessionId, OcppMessage incoming) {
     if (!(incoming.payload() instanceof Map<?, ?> rawPayload)) {
-      return accepted();
+      return response(null, accepted());
     }
 
     @SuppressWarnings("unchecked")
     Map<String, Object> payload = (Map<String, Object>) rawPayload;
     String stationId = payloadNormalizer.resolveStationId(sessionId, payload);
 
-    switch (incoming.action()) {
+    return switch (incoming.action()) {
       case "Heartbeat" -> {
-        chargingStationService.upsertStatus(
-            stationId, "ONLINE", buildAdminDetails(payload, false));
+        chargingStationService.upsertStatus(stationId, "ONLINE", buildAdminDetails(payload, false));
         stateStore.storePendingCommand(stationId, incoming.messageId(), incoming.action());
-        return Map.of("currentTime", Instant.now().toString());
+        yield response(stationId, Map.of("currentTime", Instant.now().toString()));
       }
       case "BootNotification" -> {
-        chargingStationService.upsertStatus(
-            stationId, "ONLINE", buildAdminDetails(payload, true));
+        chargingStationService.upsertStatus(stationId, "ONLINE", buildAdminDetails(payload, true));
         stateStore.storePendingCommand(stationId, incoming.messageId(), incoming.action());
-        return Map.of(
-            "status", "Accepted",
-            "currentTime", Instant.now().toString(),
-            "interval", 300);
+        yield response(
+            stationId,
+            Map.of("status", "Accepted", "currentTime", Instant.now().toString(), "interval", 300));
       }
       case "StatusNotification" -> {
         String connectorStatus =
-            stringValue(
-                payload.getOrDefault("status", payload.getOrDefault("connectorStatus", "UNKNOWN")));
+            stringValue(payload.getOrDefault("status", payload.getOrDefault("connectorStatus", "UNKNOWN")));
         int evseId = resolveEvseId(payload);
         int connectorId = resolveConnectorId(payload);
         connectorStateService.upsertConnectorState(
@@ -73,12 +69,12 @@ public class OcaOcppBridgeService {
         String aggregateStatus =
             connectorStateService.deriveStationAggregateStatus(stationId, connectorStatus);
         chargingStationService.upsertStatus(stationId, aggregateStatus, buildAdminDetails(payload, false));
-        return accepted();
+        yield response(stationId, accepted());
       }
       case "MeterValues" -> {
         telemetryIngestionService.ingestMeterValues(
             stationId, payloadNormalizer.normalizeMeterValues(stationId, payload));
-        return accepted();
+        yield response(stationId, accepted());
       }
       case "TransactionEvent" -> {
         telemetryIngestionService.ingestMeterValues(
@@ -90,14 +86,15 @@ public class OcaOcppBridgeService {
         if ("Ended".equals(eventType)) {
           chargingStationService.upsertStatus(stationId, "AVAILABLE");
         }
-        return accepted();
+        yield response(stationId, accepted());
       }
-      default -> {
-        return accepted();
-      }
-    }
+      default -> response(stationId, accepted());
+    };
   }
 
+  private OcppBridgeResponse response(String stationId, Map<String, Object> payload) {
+    return new OcppBridgeResponse(stationId, payload, stringValue(payload.get("status")));
+  }
 
   private int resolveEvseId(Map<String, Object> payload) {
     Map<String, Object> evse = mapValue(payload.get("evse"));
@@ -108,11 +105,7 @@ public class OcaOcppBridgeService {
   private int resolveConnectorId(Map<String, Object> payload) {
     Map<String, Object> evse = mapValue(payload.get("evse"));
     Object connectorId =
-        firstNonNull(
-            evse.get("connectorId"),
-            payload.get("connectorId"),
-            payload.get("connector"),
-            1);
+        firstNonNull(evse.get("connectorId"), payload.get("connectorId"), payload.get("connector"), 1);
     return intValue(connectorId, 1);
   }
 
@@ -134,11 +127,11 @@ public class OcaOcppBridgeService {
 
     String model =
         firstNonBlank(
-            stringValue(payload.get("chargePointModel")),
-            stringValue(chargingStation.get("model")));
+            stringValue(payload.get("chargePointModel")), stringValue(chargingStation.get("model")));
 
     String protocolVersion =
-        firstNonBlank(stringValue(payload.get("ocppVersion")), stringValue(payload.get("protocolVersion")));
+        firstNonBlank(
+            stringValue(payload.get("ocppVersion")), stringValue(payload.get("protocolVersion")));
 
     String firmwareVersion =
         firstNonBlank(
@@ -191,10 +184,10 @@ public class OcaOcppBridgeService {
   private String nullIfBlank(String value) {
     return (value == null || value.isBlank()) ? null : value;
   }
+
   private String stringValue(Object value) {
     return value == null ? "" : value.toString();
   }
-
 
   private Object firstNonNull(Object... values) {
     for (Object value : values) {

--- a/src/main/java/com/arthexis/platform/ocpp/OcppBridgeResponse.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppBridgeResponse.java
@@ -1,0 +1,5 @@
+package com.arthexis.platform.ocpp;
+
+import java.util.Map;
+
+public record OcppBridgeResponse(String stationId, Map<String, Object> payload, String resultStatus) {}

--- a/src/main/java/com/arthexis/platform/ocpp/OcppMessageRecord.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppMessageRecord.java
@@ -1,0 +1,92 @@
+package com.arthexis.platform.ocpp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "ocpp_message_record")
+public class OcppMessageRecord {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "session_record_id")
+  private OcppSessionRecord sessionRecord;
+
+  @Column(name = "session_id", nullable = false, length = 128)
+  private String sessionId;
+
+  @Column(name = "station_id", length = 64)
+  private String stationId;
+
+  @Column(name = "direction", nullable = false, length = 16)
+  private String direction;
+
+  @Column(name = "message_type", length = 32)
+  private String messageType;
+
+  @Column(name = "action", length = 64)
+  private String action;
+
+  @Column(name = "message_id", length = 128)
+  private String messageId;
+
+  @Column(name = "payload_snapshot", nullable = false, length = 8000)
+  private String payloadSnapshot;
+
+  @Column(name = "payload_truncated", nullable = false)
+  private boolean payloadTruncated;
+
+  @Column(name = "parse_status", nullable = false, length = 32)
+  private String parseStatus;
+
+  @Column(name = "result_status", length = 64)
+  private String resultStatus;
+
+  @Column(name = "sampled_at", nullable = false)
+  private Instant sampledAt;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  protected OcppMessageRecord() {}
+
+  public OcppMessageRecord(
+      OcppSessionRecord sessionRecord,
+      String sessionId,
+      String stationId,
+      String direction,
+      String messageType,
+      String action,
+      String messageId,
+      String payloadSnapshot,
+      boolean payloadTruncated,
+      String parseStatus,
+      String resultStatus,
+      Instant sampledAt,
+      Instant createdAt) {
+    this.sessionRecord = sessionRecord;
+    this.sessionId = sessionId;
+    this.stationId = stationId;
+    this.direction = direction;
+    this.messageType = messageType;
+    this.action = action;
+    this.messageId = messageId;
+    this.payloadSnapshot = payloadSnapshot;
+    this.payloadTruncated = payloadTruncated;
+    this.parseStatus = parseStatus;
+    this.resultStatus = resultStatus;
+    this.sampledAt = sampledAt;
+    this.createdAt = createdAt;
+  }
+}

--- a/src/main/java/com/arthexis/platform/ocpp/OcppMessageRecordRepository.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppMessageRecordRepository.java
@@ -1,0 +1,5 @@
+package com.arthexis.platform.ocpp;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OcppMessageRecordRepository extends JpaRepository<OcppMessageRecord, Long> {}

--- a/src/main/java/com/arthexis/platform/ocpp/OcppSessionAuditService.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppSessionAuditService.java
@@ -1,0 +1,154 @@
+package com.arthexis.platform.ocpp;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OcppSessionAuditService {
+
+  private static final int PAYLOAD_SNAPSHOT_LIMIT = 8000;
+
+  private final OcppSessionRecordRepository sessionRepository;
+  private final OcppMessageRecordRepository messageRepository;
+  private final ObjectMapper objectMapper;
+
+  public OcppSessionAuditService(
+      OcppSessionRecordRepository sessionRepository,
+      OcppMessageRecordRepository messageRepository,
+      ObjectMapper objectMapper) {
+    this.sessionRepository = sessionRepository;
+    this.messageRepository = messageRepository;
+    this.objectMapper = objectMapper;
+  }
+
+  public void markSessionConnected(String sessionId) {
+    Instant now = Instant.now();
+    OcppSessionRecord session =
+        sessionRepository
+            .findBySessionId(sessionId)
+            .orElseGet(() -> new OcppSessionRecord(sessionId, now));
+    session.setDisconnectedAt(null);
+    session.setUpdatedAt(now);
+    sessionRepository.save(session);
+  }
+
+  public void markSessionDisconnected(String sessionId) {
+    sessionRepository
+        .findBySessionId(sessionId)
+        .ifPresent(
+            existing -> {
+              Instant now = Instant.now();
+              existing.setDisconnectedAt(now);
+              existing.setUpdatedAt(now);
+              sessionRepository.save(existing);
+            });
+  }
+
+  public void recordIncomingParsed(String sessionId, OcppMessage incoming, String stationId, String rawPayload) {
+    recordMessage(
+        sessionId,
+        stationId,
+        "INBOUND",
+        incoming.messageType(),
+        incoming.action(),
+        incoming.messageId(),
+        rawPayload,
+        "PARSED",
+        null);
+  }
+
+  public void recordIncomingParseFailure(String sessionId, String rawPayload) {
+    recordMessage(
+        sessionId,
+        null,
+        "INBOUND",
+        null,
+        null,
+        null,
+        rawPayload,
+        "PARSE_FAILED",
+        "InvalidJson");
+  }
+
+  public void recordOutgoingCallResult(
+      String sessionId, OcppMessage outgoing, String stationId, String resultStatus) {
+    recordMessage(
+        sessionId,
+        stationId,
+        "OUTBOUND",
+        outgoing.messageType(),
+        outgoing.action(),
+        outgoing.messageId(),
+        payloadToString(outgoing.payload()),
+        "PARSED",
+        resultStatus);
+  }
+
+  private void recordMessage(
+      String sessionId,
+      String stationId,
+      String direction,
+      String messageType,
+      String action,
+      String messageId,
+      String payload,
+      String parseStatus,
+      String resultStatus) {
+    Instant now = Instant.now();
+    OcppSessionRecord session =
+        sessionRepository
+            .findBySessionId(sessionId)
+            .orElseGet(() -> new OcppSessionRecord(sessionId, now));
+
+    if (stationId != null && !stationId.isBlank()) {
+      session.setStationId(stationId);
+    }
+    session.setLastMessageAt(now);
+    session.setUpdatedAt(now);
+    OcppSessionRecord persistedSession = sessionRepository.save(session);
+
+    Snapshot snapshot = truncate(payload);
+    messageRepository.save(
+        new OcppMessageRecord(
+            persistedSession,
+            sessionId,
+            session.getStationId(),
+            direction,
+            messageType,
+            action,
+            messageId,
+            snapshot.value(),
+            snapshot.truncated(),
+            parseStatus,
+            resultStatus,
+            now,
+            now));
+  }
+
+  private String payloadToString(Object payload) {
+    if (payload == null) {
+      return "{}";
+    }
+    if (payload instanceof String textPayload) {
+      return textPayload;
+    }
+    try {
+      return objectMapper.writeValueAsString(payload);
+    } catch (JsonProcessingException ex) {
+      return String.valueOf(payload);
+    }
+  }
+
+  private Snapshot truncate(String payload) {
+    String normalized = Optional.ofNullable(payload).orElse("{}");
+    if (normalized.length() <= PAYLOAD_SNAPSHOT_LIMIT) {
+      return new Snapshot(normalized, false);
+    }
+    return new Snapshot(normalized.substring(0, PAYLOAD_SNAPSHOT_LIMIT), true);
+  }
+
+  private record Snapshot(String value, boolean truncated) {}
+}

--- a/src/main/java/com/arthexis/platform/ocpp/OcppSessionRecord.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppSessionRecord.java
@@ -1,0 +1,96 @@
+package com.arthexis.platform.ocpp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "ocpp_session")
+public class OcppSessionRecord {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "session_id", nullable = false, unique = true, length = 128)
+  private String sessionId;
+
+  @Column(name = "station_id", length = 64)
+  private String stationId;
+
+  @Column(name = "connected_at", nullable = false)
+  private Instant connectedAt;
+
+  @Column(name = "disconnected_at")
+  private Instant disconnectedAt;
+
+  @Column(name = "last_message_at")
+  private Instant lastMessageAt;
+
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  protected OcppSessionRecord() {}
+
+  public OcppSessionRecord(String sessionId, Instant connectedAt) {
+    this.sessionId = sessionId;
+    this.connectedAt = connectedAt;
+    this.createdAt = connectedAt;
+    this.updatedAt = connectedAt;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public String getSessionId() {
+    return sessionId;
+  }
+
+  public String getStationId() {
+    return stationId;
+  }
+
+  public void setStationId(String stationId) {
+    this.stationId = stationId;
+  }
+
+  public Instant getConnectedAt() {
+    return connectedAt;
+  }
+
+  public Instant getDisconnectedAt() {
+    return disconnectedAt;
+  }
+
+  public void setDisconnectedAt(Instant disconnectedAt) {
+    this.disconnectedAt = disconnectedAt;
+  }
+
+  public Instant getLastMessageAt() {
+    return lastMessageAt;
+  }
+
+  public void setLastMessageAt(Instant lastMessageAt) {
+    this.lastMessageAt = lastMessageAt;
+  }
+
+  public Instant getCreatedAt() {
+    return createdAt;
+  }
+
+  public Instant getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(Instant updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+}

--- a/src/main/java/com/arthexis/platform/ocpp/OcppSessionRecordRepository.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppSessionRecordRepository.java
@@ -1,0 +1,8 @@
+package com.arthexis.platform.ocpp;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OcppSessionRecordRepository extends JpaRepository<OcppSessionRecord, Long> {
+  Optional<OcppSessionRecord> findBySessionId(String sessionId);
+}

--- a/src/main/java/com/arthexis/platform/ocpp/OcppWebSocketHandler.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppWebSocketHandler.java
@@ -3,6 +3,7 @@ package com.arthexis.platform.ocpp;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
@@ -12,21 +13,47 @@ public class OcppWebSocketHandler extends TextWebSocketHandler {
 
   private final ObjectMapper objectMapper;
   private final OcaOcppBridgeService ocaOcppBridgeService;
+  private final OcppSessionAuditService sessionAuditService;
 
-  public OcppWebSocketHandler(ObjectMapper objectMapper, OcaOcppBridgeService ocaOcppBridgeService) {
+  public OcppWebSocketHandler(
+      ObjectMapper objectMapper,
+      OcaOcppBridgeService ocaOcppBridgeService,
+      OcppSessionAuditService sessionAuditService) {
     this.objectMapper = objectMapper;
     this.ocaOcppBridgeService = ocaOcppBridgeService;
+    this.sessionAuditService = sessionAuditService;
+  }
+
+  @Override
+  public void afterConnectionEstablished(WebSocketSession session) {
+    sessionAuditService.markSessionConnected(session.getId());
+  }
+
+  @Override
+  public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+    sessionAuditService.markSessionDisconnected(session.getId());
   }
 
   @Override
   protected void handleTextMessage(WebSocketSession session, TextMessage message) throws IOException {
-    OcppMessage incoming = objectMapper.readValue(message.getPayload(), OcppMessage.class);
+    OcppMessage incoming;
+    try {
+      incoming = objectMapper.readValue(message.getPayload(), OcppMessage.class);
+    } catch (IOException ex) {
+      sessionAuditService.recordIncomingParseFailure(session.getId(), message.getPayload());
+      throw ex;
+    }
+
+    OcppBridgeResponse bridgeResponse = ocaOcppBridgeService.handleIncoming(session.getId(), incoming);
+    sessionAuditService.recordIncomingParsed(
+        session.getId(), incoming, bridgeResponse.stationId(), message.getPayload());
+
     OcppMessage ack =
         new OcppMessage(
-            "CALLRESULT",
-            incoming.messageId(),
-            incoming.action(),
-            ocaOcppBridgeService.handleIncoming(session.getId(), incoming));
+            "CALLRESULT", incoming.messageId(), incoming.action(), bridgeResponse.payload());
+    sessionAuditService.recordOutgoingCallResult(
+        session.getId(), ack, bridgeResponse.stationId(), bridgeResponse.resultStatus());
+
     session.sendMessage(new TextMessage(objectMapper.writeValueAsString(ack)));
   }
 }

--- a/src/main/resources/db/migration/V5__add_ocpp_sessions_and_messages.sql
+++ b/src/main/resources/db/migration/V5__add_ocpp_sessions_and_messages.sql
@@ -1,0 +1,36 @@
+CREATE TABLE ocpp_session (
+    id BIGSERIAL PRIMARY KEY,
+    session_id VARCHAR(128) NOT NULL UNIQUE,
+    station_id VARCHAR(64),
+    connected_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    disconnected_at TIMESTAMP WITH TIME ZONE,
+    last_message_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE ocpp_message_record (
+    id BIGSERIAL PRIMARY KEY,
+    session_record_id BIGINT REFERENCES ocpp_session(id),
+    session_id VARCHAR(128) NOT NULL,
+    station_id VARCHAR(64),
+    direction VARCHAR(16) NOT NULL,
+    message_type VARCHAR(32),
+    action VARCHAR(64),
+    message_id VARCHAR(128),
+    payload_snapshot VARCHAR(8000) NOT NULL,
+    payload_truncated BOOLEAN NOT NULL DEFAULT FALSE,
+    parse_status VARCHAR(32) NOT NULL,
+    result_status VARCHAR(64),
+    sampled_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_ocpp_session_station_last_message
+    ON ocpp_session(station_id, last_message_at DESC);
+
+CREATE INDEX idx_ocpp_msg_station_action_sampled
+    ON ocpp_message_record(station_id, action, sampled_at DESC);
+
+CREATE INDEX idx_ocpp_msg_station_sampled
+    ON ocpp_message_record(station_id, sampled_at DESC);

--- a/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeStatusNotificationTests.java
+++ b/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeStatusNotificationTests.java
@@ -69,9 +69,9 @@ class OcaOcppBridgeStatusNotificationTests {
                 "connectorType", "CCS2",
                 "availability", "Operative"));
 
-    Map<String, Object> response = bridgeService.handleIncoming("session-1", incoming);
+    OcppBridgeResponse response = bridgeService.handleIncoming("session-1", incoming);
 
-    assertThat(response).containsEntry("status", "Accepted");
+    assertThat(response.payload()).containsEntry("status", "Accepted");
 
     ArgumentCaptor<ChargingStation> stationCaptor = ArgumentCaptor.forClass(ChargingStation.class);
     verify(chargingStationRepository).save(stationCaptor.capture());


### PR DESCRIPTION
### Motivation
- Provide durable audit storage for OCPP sessions and messages (direction, action, messageId, stationId, payload snapshot, parse/result status and timestamps) to support admin queries and troubleshooting.
- Capture session lifecycle and message-level metadata at the websocket boundary so incoming messages and generated CALLRESULTs can be inspected and correlated with station state.
- Keep message payload storage bounded to avoid unbounded DB growth while preserving a truncation indicator for diagnostics.

### Description
- Added Flyway migration `V5__add_ocpp_sessions_and_messages.sql` to create `ocpp_session` and `ocpp_message_record` tables and indexes for `station_id`, `action`, and `sampled_at` query patterns.
- Introduced JPA entities and repositories: `OcppSessionRecord`, `OcppSessionRecordRepository`, `OcppMessageRecord`, and `OcppMessageRecordRepository` to persist sessions and message records.
- Implemented `OcppSessionAuditService` which upserts session state (connect/disconnect/last message), records inbound parse failures, inbound parsed messages, and outbound CALLRESULTs, and truncates payload snapshots to an 8000 character limit with a `payloadTruncated` flag.
- Extended `OcaOcppBridgeService` to return an `OcppBridgeResponse` (stationId, payload, resultStatus) so the websocket handler can persist station and result metadata without duplicating parsing logic.
- Extended `OcppWebSocketHandler` to mark session connect/disconnect, record parse failures, persist inbound parsed messages using station context, and persist outgoing CALLRESULTs.
- Updated tests to the new bridge response shape (`OcaOcppBridgeStatusNotificationTests`) and added/adjusted imports as necessary.

### Testing
- Ran `mvn -q test` and the test suite passed after the changes (Flyway applied new migration successfully during tests). 
- Ran `mvn -q spotless:check` which failed in this environment due to a `google-java-format`/Spotless incompatibility with the installed JDK (`NoSuchMethodError` from `com.sun.tools.javac`), unrelated to the functional changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0abb94988326bcc4297fea0da35f)