### PR TITLE
Expand CI coverage to validate upgrade installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        install_mode: [new-install, upgrade-install]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
@@ -16,14 +20,21 @@ jobs:
           distribution: temurin
           java-version: "21"
           cache: maven
-      - name: Verify
+      - name: Verify (${{ matrix.install_mode }})
         id: verify
         continue-on-error: true
         shell: bash
         run: |
           set -o pipefail
           set +e
-          mvn -B verify 2>&1 | tee ci-verify.log
+
+          if [ "${{ matrix.install_mode }}" = "new-install" ]; then
+            verify_command="mvn -B verify"
+          else
+            verify_command="mvn -B -Dtest=FlywayUpgradePathTests test"
+          fi
+
+          bash -lc "$verify_command" 2>&1 | tee ci-verify.log
           status=${PIPESTATUS[0]}
           set -e
           echo "status=$status" >> "$GITHUB_OUTPUT"
@@ -46,14 +57,15 @@ jobs:
           ERROR_MESSAGE: ${{ steps.verify.outputs.error_message }}
         with:
           script: |
-            const marker = '<!-- arthexis-ci-failure -->';
+            const marker = `<!-- arthexis-ci-failure-${{ matrix.install_mode }} -->`;
+            const mode = '${{ matrix.install_mode }}';
             const raw = process.env.ERROR_MESSAGE || 'No error details captured.';
             const maxLength = 65000;
             const content = raw.length > maxLength
               ? `${raw.slice(0, maxLength)}\n... (truncated)`
               : raw;
             const body = `${marker}
-            ⚠️ CI failed during \`mvn -B verify\`.
+            ⚠️ CI failed during ${mode} validation.
 
             \`\`\`text
             ${content}
@@ -86,5 +98,5 @@ jobs:
       - name: Fail workflow if verify failed
         if: steps.verify.outputs.status != '0'
         run: |
-          echo "Verification failed."
+          echo "Verification failed for install mode: ${{ matrix.install_mode }}"
           exit 1

--- a/src/test/java/com/arthexis/platform/FlywayUpgradePathTests.java
+++ b/src/test/java/com/arthexis/platform/FlywayUpgradePathTests.java
@@ -1,0 +1,53 @@
+package com.arthexis.platform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.DriverManager;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.MigrationVersion;
+import org.flywaydb.core.api.output.MigrateResult;
+import org.junit.jupiter.api.Test;
+
+class FlywayUpgradePathTests {
+
+  @Test
+  void migratesExistingInstallFromV1ToLatest() throws Exception {
+    Path databaseFile = Files.createTempFile("arthexis-upgrade", ".db");
+    String databaseUrl =
+        "jdbc:h2:file:"
+            + databaseFile.toAbsolutePath()
+            + ";MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH";
+
+    Flyway initialInstallMigrations =
+        flywayFor(databaseUrl).target(MigrationVersion.fromVersion("1")).load();
+    MigrateResult initialInstallResult = initialInstallMigrations.migrate();
+
+    assertThat(initialInstallResult.success).isTrue();
+    assertThat(initialInstallMigrations.info().current()).isNotNull();
+    assertThat(initialInstallMigrations.info().current().getVersion().getVersion()).isEqualTo("1");
+
+    Flyway upgradeMigrations = flywayFor(databaseUrl).load();
+    MigrateResult upgradeResult = upgradeMigrations.migrate();
+
+    assertThat(upgradeResult.success).isTrue();
+    assertThat(upgradeResult.migrationsExecuted).isGreaterThan(0);
+    assertThat(upgradeMigrations.info().current()).isNotNull();
+    assertThat(upgradeMigrations.info().current().getVersion())
+        .isGreaterThan(MigrationVersion.fromVersion("1"));
+    assertThat(upgradeMigrations.info().pending()).isEmpty();
+
+    DriverManager.getConnection(databaseUrl, "sa", "").close();
+    Files.deleteIfExists(databaseFile);
+    Files.deleteIfExists(Path.of(databaseFile + ".mv.db"));
+    Files.deleteIfExists(Path.of(databaseFile + ".trace.db"));
+  }
+
+  private org.flywaydb.core.api.configuration.FluentConfiguration flywayFor(String databaseUrl) {
+    return Flyway.configure()
+        .locations("classpath:db/migration")
+        .dataSource(databaseUrl, "sa", "")
+        .cleanDisabled(true);
+  }
+}


### PR DESCRIPTION
### Motivation
- Ensure CI validates both fresh installations and in-place schema upgrades so database migrations are exercised before changes are merged.
- Keep PR failure comments but scope them per validation mode to avoid comment collisions between lanes.
- Add an automated test that reproduces an upgrade path from an initial install to the current schema to catch migration regressions early.

### Description
- Update `.github/workflows/ci.yml` to run a matrix `install_mode` with `new-install` and `upgrade-install` lanes and run a different verification command per mode (`mvn -B verify` for `new-install`, `mvn -B -Dtest=FlywayUpgradePathTests test` for `upgrade-install`).
- Make PR failure comments mode-specific by using markers like `<!-- arthexis-ci-failure-${{ matrix.install_mode }} -->` and include the mode name in the failure message.
- Add `src/test/java/com/arthexis/platform/FlywayUpgradePathTests.java` which uses Flyway to create an H2 database at version `1`, run subsequent migrations to latest, and assert migrations succeeded with no pending migrations, implemented using `org.flywaydb.core.api.configuration.FluentConfiguration`.

### Testing
- Ran `mvn -B -Dtest=FlywayUpgradePathTests test` which initially hit a transient Maven Central `502 Bad Gateway` during dependency resolution and failed; this was transient and not related to the change.
- Fixed a compile-time reference in the test and re-ran `mvn -B -Dtest=FlywayUpgradePathTests test`, which completed successfully (tests: 1 run, 0 failures).
- The CI workflow now executes both lanes locally via the added matrix logic in the workflow file (`new-install` and `upgrade-install`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0e63d6fc83269f37b01fff44aa11)