### PR TITLE
Add observability budgets for startup and Flyway migrations

### DIFF
--- a/src/main/java/com/arthexis/platform/operations/RuntimeBudgetConfiguration.java
+++ b/src/main/java/com/arthexis/platform/operations/RuntimeBudgetConfiguration.java
@@ -1,0 +1,29 @@
+package com.arthexis.platform.operations;
+
+import java.time.Duration;
+import org.flywaydb.core.Flyway;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(RuntimeBudgetProperties.class)
+public class RuntimeBudgetConfiguration {
+
+  @Bean
+  @ConditionalOnClass(Flyway.class)
+  @ConditionalOnMissingBean(FlywayMigrationStrategy.class)
+  FlywayMigrationStrategy migrationBudgetStrategy(
+      RuntimeBudgetRecorder runtimeBudgetRecorder, RuntimeBudgetProperties runtimeBudgetProperties) {
+    return flyway -> {
+      long startedAt = System.nanoTime();
+      flyway.migrate();
+      Duration migrationDuration = Duration.ofNanos(System.nanoTime() - startedAt);
+      runtimeBudgetRecorder.record(
+          "migration", migrationDuration, runtimeBudgetProperties.getMigrationBudget());
+    };
+  }
+}

--- a/src/main/java/com/arthexis/platform/operations/RuntimeBudgetProperties.java
+++ b/src/main/java/com/arthexis/platform/operations/RuntimeBudgetProperties.java
@@ -1,0 +1,27 @@
+package com.arthexis.platform.operations;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "arthexis.runtime")
+public class RuntimeBudgetProperties {
+
+  private Duration startupBudget = Duration.ofSeconds(90);
+  private Duration migrationBudget = Duration.ofSeconds(30);
+
+  public Duration getStartupBudget() {
+    return startupBudget;
+  }
+
+  public void setStartupBudget(Duration startupBudget) {
+    this.startupBudget = startupBudget;
+  }
+
+  public Duration getMigrationBudget() {
+    return migrationBudget;
+  }
+
+  public void setMigrationBudget(Duration migrationBudget) {
+    this.migrationBudget = migrationBudget;
+  }
+}

--- a/src/main/java/com/arthexis/platform/operations/RuntimeBudgetRecorder.java
+++ b/src/main/java/com/arthexis/platform/operations/RuntimeBudgetRecorder.java
@@ -1,0 +1,50 @@
+package com.arthexis.platform.operations;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RuntimeBudgetRecorder {
+
+  private static final Logger logger = LoggerFactory.getLogger(RuntimeBudgetRecorder.class);
+
+  private final MeterRegistry meterRegistry;
+
+  public RuntimeBudgetRecorder(MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+  }
+
+  public void record(String phase, Duration actualDuration, Duration budget) {
+    Timer.builder("arthexis.runtime.phase.duration")
+        .description("Startup and migration durations by phase")
+        .tag("phase", phase)
+        .register(meterRegistry)
+        .record(actualDuration);
+
+    if (actualDuration.compareTo(budget) > 0) {
+      Counter.builder("arthexis.runtime.phase.over_budget.total")
+          .description("Number of times runtime phases exceeded budget")
+          .tag("phase", phase)
+          .register(meterRegistry)
+          .increment();
+      logger.warn(
+          "Runtime phase '{}' exceeded budget (actual={}ms, budget={}ms). "
+              + "This does not stop the live instance; investigate and tune rollout plans.",
+          phase,
+          actualDuration.toMillis(),
+          budget.toMillis());
+      return;
+    }
+
+    logger.info(
+        "Runtime phase '{}' completed within budget (actual={}ms, budget={}ms).",
+        phase,
+        actualDuration.toMillis(),
+        budget.toMillis());
+  }
+}

--- a/src/main/java/com/arthexis/platform/operations/StartupBudgetMonitor.java
+++ b/src/main/java/com/arthexis/platform/operations/StartupBudgetMonitor.java
@@ -1,0 +1,26 @@
+package com.arthexis.platform.operations;
+
+import java.time.Duration;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StartupBudgetMonitor {
+
+  private final RuntimeBudgetRecorder runtimeBudgetRecorder;
+  private final RuntimeBudgetProperties runtimeBudgetProperties;
+
+  public StartupBudgetMonitor(
+      RuntimeBudgetRecorder runtimeBudgetRecorder, RuntimeBudgetProperties runtimeBudgetProperties) {
+    this.runtimeBudgetRecorder = runtimeBudgetRecorder;
+    this.runtimeBudgetProperties = runtimeBudgetProperties;
+  }
+
+  @EventListener
+  public void onApplicationReady(ApplicationReadyEvent event) {
+    Duration startupDuration = event.getTimeTaken() != null ? event.getTimeTaken() : Duration.ZERO;
+    runtimeBudgetRecorder.record(
+        "startup", startupDuration, runtimeBudgetProperties.getStartupBudget());
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,9 @@ management:
         enabled: true
 
 arthexis:
+  runtime:
+    startup-budget: 90s
+    migration-budget: 30s
   jobs:
     station-poll-delay-ms: 60000
 

--- a/src/test/java/com/arthexis/platform/operations/RuntimeBudgetConfigurationTests.java
+++ b/src/test/java/com/arthexis/platform/operations/RuntimeBudgetConfigurationTests.java
@@ -1,0 +1,34 @@
+package com.arthexis.platform.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+
+class RuntimeBudgetConfigurationTests {
+
+  @Test
+  void migrationStrategyRunsFlywayAndRecordsMetrics() {
+    var meterRegistry = new SimpleMeterRegistry();
+    var recorder = new RuntimeBudgetRecorder(meterRegistry);
+    var properties = new RuntimeBudgetProperties();
+    properties.setMigrationBudget(Duration.ofMillis(1));
+
+    FlywayMigrationStrategy strategy =
+        new RuntimeBudgetConfiguration().migrationBudgetStrategy(recorder, properties);
+
+    Flyway flyway =
+        Flyway.configure()
+            .dataSource("jdbc:h2:mem:runtime_budget_config;DB_CLOSE_DELAY=-1", "sa", "")
+            .locations("classpath:db/migration")
+            .load();
+
+    strategy.migrate(flyway);
+
+    assertThat(meterRegistry.get("arthexis.runtime.phase.duration").tag("phase", "migration").timer())
+        .isNotNull();
+  }
+}

--- a/src/test/java/com/arthexis/platform/operations/RuntimeBudgetRecorderTests.java
+++ b/src/test/java/com/arthexis/platform/operations/RuntimeBudgetRecorderTests.java
@@ -1,0 +1,41 @@
+package com.arthexis.platform.operations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class RuntimeBudgetRecorderTests {
+
+  @Test
+  void incrementsOverBudgetCounterWhenDurationExceedsBudget() {
+    var meterRegistry = new SimpleMeterRegistry();
+    var recorder = new RuntimeBudgetRecorder(meterRegistry);
+
+    recorder.record("startup", Duration.ofSeconds(5), Duration.ofSeconds(1));
+
+    assertThat(
+            meterRegistry
+                .get("arthexis.runtime.phase.over_budget.total")
+                .tag("phase", "startup")
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void doesNotIncrementOverBudgetCounterWhenDurationIsWithinBudget() {
+    var meterRegistry = new SimpleMeterRegistry();
+    var recorder = new RuntimeBudgetRecorder(meterRegistry);
+
+    recorder.record("migration", Duration.ofSeconds(3), Duration.ofSeconds(3));
+
+    assertThat(
+            meterRegistry
+                .find("arthexis.runtime.phase.over_budget.total")
+                .tag("phase", "migration")
+                .counter())
+        .isNull();
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide SLO-style visibility into startup and DB migration time so operators can act when those phases run long. 
- Surface overruns as metrics and warnings without imposing a hard kill or blocking live instances. 
- Make budgets configurable per deployment so teams can tune expectations per environment.

### Description
- Add `RuntimeBudgetProperties` bound to `arthexis.runtime` with `startupBudget` and `migrationBudget` and sensible defaults.  
- Add `RuntimeBudgetRecorder` which records `arthexis.runtime.phase.duration` and increments `arthexis.runtime.phase.over_budget.total` when a phase exceeds budget and emits clear log warnings.  
- Add `StartupBudgetMonitor` which listens for `ApplicationReadyEvent` and records startup duration against the configured startup budget.  
- Add `RuntimeBudgetConfiguration` which registers a `FlywayMigrationStrategy` wrapper that times `flyway.migrate()` and records migration durations, and add defaults to `src/main/resources/application.yml`; also add focused unit tests for recorder and migration wiring.

### Testing
- Ran the focused tests with `mvn -q -Dtest='RuntimeBudget*Tests' test` which completed successfully and validated `RuntimeBudgetRecorderTests` and `RuntimeBudgetConfigurationTests`.  
- An earlier full `mvn -q test` run reported a single test error due to Mockito/ByteBuddy inline-mocking of `Flyway` on Java 25 (mocking limitation), which was addressed by using a real `Flyway` instance in the test; the focused test run then passed.  
- Tests added: `RuntimeBudgetRecorderTests` and `RuntimeBudgetConfigurationTests`, both exercised metric registration and migration strategy wiring and passed in the targeted run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc17889cf483269923d20ac391c54e)