### PR TITLE
Add admin STOMP websocket and domain-event bridge with role-gated access

### DIFF
--- a/src/main/java/com/arthexis/platform/app/admin/AdminDomainEvent.java
+++ b/src/main/java/com/arthexis/platform/app/admin/AdminDomainEvent.java
@@ -1,0 +1,14 @@
+package com.arthexis.platform.app.admin;
+
+import java.time.Instant;
+
+public sealed interface AdminDomainEvent
+    permits ConnectorChangedEvent,
+        OcppMessagePersistedEvent,
+        StationStatusChangedEvent,
+        TelemetrySummaryEvent {
+
+  String stationId();
+
+  Instant occurredAt();
+}

--- a/src/main/java/com/arthexis/platform/app/admin/AdminRealtimePayload.java
+++ b/src/main/java/com/arthexis/platform/app/admin/AdminRealtimePayload.java
@@ -1,0 +1,7 @@
+package com.arthexis.platform.app.admin;
+
+import java.time.Instant;
+import java.util.Map;
+
+public record AdminRealtimePayload(
+    String eventType, String stationId, Instant occurredAt, Map<String, Object> details) {}

--- a/src/main/java/com/arthexis/platform/app/admin/AdminWebSocketCommandController.java
+++ b/src/main/java/com/arthexis/platform/app/admin/AdminWebSocketCommandController.java
@@ -1,0 +1,33 @@
+package com.arthexis.platform.app.admin;
+
+import java.security.Principal;
+import java.time.Instant;
+import java.util.Map;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class AdminWebSocketCommandController {
+
+  public static final String ADMIN_COMMAND_DESTINATION = "/app/admin/commands";
+
+  private final SimpMessagingTemplate messagingTemplate;
+
+  public AdminWebSocketCommandController(SimpMessagingTemplate messagingTemplate) {
+    this.messagingTemplate = messagingTemplate;
+  }
+
+  @MessageMapping("/admin/commands")
+  public void relay(@Payload Map<String, Object> command, Principal principal) {
+    String user = principal == null ? "unknown" : principal.getName();
+    AdminRealtimePayload payload =
+        new AdminRealtimePayload(
+            "admin.command.received",
+            String.valueOf(command.getOrDefault("stationId", "unknown")),
+            Instant.now(),
+            Map.of("user", user, "command", command));
+    messagingTemplate.convertAndSend(AdminWebSocketDomainEventBridge.ADMIN_TOPIC_EVENTS, payload);
+  }
+}

--- a/src/main/java/com/arthexis/platform/app/admin/AdminWebSocketDomainEventBridge.java
+++ b/src/main/java/com/arthexis/platform/app/admin/AdminWebSocketDomainEventBridge.java
@@ -1,0 +1,69 @@
+package com.arthexis.platform.app.admin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminWebSocketDomainEventBridge {
+
+  public static final String ADMIN_TOPIC_EVENTS = "/topic/admin/events";
+
+  private final SimpMessagingTemplate messagingTemplate;
+
+  public AdminWebSocketDomainEventBridge(SimpMessagingTemplate messagingTemplate) {
+    this.messagingTemplate = messagingTemplate;
+  }
+
+  @EventListener
+  public void onStationStatusChanged(StationStatusChangedEvent event) {
+    Map<String, Object> details = new LinkedHashMap<>();
+    details.put("status", event.status());
+    details.put("previousStatus", event.previousStatus());
+    details.put("tenantId", event.tenantId());
+    details.put("siteId", event.siteId());
+
+    publish(new AdminRealtimePayload("station.status.changed", event.stationId(), event.occurredAt(), details));
+  }
+
+  @EventListener
+  public void onConnectorChanged(ConnectorChangedEvent event) {
+    Map<String, Object> details = new LinkedHashMap<>();
+    details.put("evseId", event.evseId());
+    details.put("connectorId", event.connectorId());
+    details.put("status", event.status());
+    details.put("connectorType", event.connectorType());
+    details.put("availability", event.availability());
+
+    publish(new AdminRealtimePayload("connector.changed", event.stationId(), event.occurredAt(), details));
+  }
+
+  @EventListener
+  public void onTelemetrySummary(TelemetrySummaryEvent event) {
+    Map<String, Object> details = new LinkedHashMap<>();
+    details.put("totalSamples", event.totalSamples());
+    details.put("structuredSamples", event.structuredSamples());
+    details.put("numericPayloadSamples", event.numericPayloadSamples());
+    details.put("sampledAt", event.sampledAt());
+
+    publish(new AdminRealtimePayload("telemetry.summary", event.stationId(), event.occurredAt(), details));
+  }
+
+  @EventListener
+  public void onSessionEvent(OcppMessagePersistedEvent event) {
+    Map<String, Object> details = new LinkedHashMap<>();
+    details.put("sessionId", event.sessionId());
+    details.put("direction", event.direction());
+    details.put("action", event.action());
+    details.put("parseStatus", event.parseStatus());
+    details.put("resultStatus", event.resultStatus());
+
+    publish(new AdminRealtimePayload("session.message.persisted", event.stationId(), event.occurredAt(), details));
+  }
+
+  private void publish(AdminRealtimePayload payload) {
+    messagingTemplate.convertAndSend(ADMIN_TOPIC_EVENTS, payload);
+  }
+}

--- a/src/main/java/com/arthexis/platform/app/admin/ConnectorChangedEvent.java
+++ b/src/main/java/com/arthexis/platform/app/admin/ConnectorChangedEvent.java
@@ -1,0 +1,13 @@
+package com.arthexis.platform.app.admin;
+
+import java.time.Instant;
+
+public record ConnectorChangedEvent(
+    String stationId,
+    Integer evseId,
+    Integer connectorId,
+    String status,
+    String connectorType,
+    String availability,
+    Instant occurredAt)
+    implements AdminDomainEvent {}

--- a/src/main/java/com/arthexis/platform/app/admin/OcppMessagePersistedEvent.java
+++ b/src/main/java/com/arthexis/platform/app/admin/OcppMessagePersistedEvent.java
@@ -1,0 +1,13 @@
+package com.arthexis.platform.app.admin;
+
+import java.time.Instant;
+
+public record OcppMessagePersistedEvent(
+    String stationId,
+    String sessionId,
+    String direction,
+    String action,
+    String parseStatus,
+    String resultStatus,
+    Instant occurredAt)
+    implements AdminDomainEvent {}

--- a/src/main/java/com/arthexis/platform/app/admin/StationStatusChangedEvent.java
+++ b/src/main/java/com/arthexis/platform/app/admin/StationStatusChangedEvent.java
@@ -1,0 +1,12 @@
+package com.arthexis.platform.app.admin;
+
+import java.time.Instant;
+
+public record StationStatusChangedEvent(
+    String stationId,
+    String status,
+    String previousStatus,
+    String tenantId,
+    String siteId,
+    Instant occurredAt)
+    implements AdminDomainEvent {}

--- a/src/main/java/com/arthexis/platform/app/admin/TelemetrySummaryEvent.java
+++ b/src/main/java/com/arthexis/platform/app/admin/TelemetrySummaryEvent.java
@@ -1,0 +1,12 @@
+package com.arthexis.platform.app.admin;
+
+import java.time.Instant;
+
+public record TelemetrySummaryEvent(
+    String stationId,
+    int totalSamples,
+    int structuredSamples,
+    int numericPayloadSamples,
+    Instant sampledAt,
+    Instant occurredAt)
+    implements AdminDomainEvent {}

--- a/src/main/java/com/arthexis/platform/app/admin/package-info.java
+++ b/src/main/java/com/arthexis/platform/app/admin/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.modulith.NamedInterface("admin-events")
+package com.arthexis.platform.app.admin;

--- a/src/main/java/com/arthexis/platform/charging/ChargingStationService.java
+++ b/src/main/java/com/arthexis/platform/charging/ChargingStationService.java
@@ -1,5 +1,8 @@
 package com.arthexis.platform.charging;
 
+import com.arthexis.platform.app.admin.StationStatusChangedEvent;
+import java.time.Instant;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,9 +10,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChargingStationService {
 
   private final ChargingStationRepository repository;
+  private final ApplicationEventPublisher eventPublisher;
 
-  public ChargingStationService(ChargingStationRepository repository) {
+  public ChargingStationService(
+      ChargingStationRepository repository, ApplicationEventPublisher eventPublisher) {
     this.repository = repository;
+    this.eventPublisher = eventPublisher;
   }
 
   @Transactional
@@ -25,10 +31,25 @@ public class ChargingStationService {
             .findByStationId(stationId)
             .orElseGet(() -> new ChargingStation(stationId, defaultStatus(status)));
 
-    station.heartbeat(defaultStatus(status));
+    String previousStatus = station.getStatus();
+    String resolvedStatus = defaultStatus(status);
+    station.heartbeat(resolvedStatus);
     station.applyAdminDetails(adminDetails);
 
-    return repository.save(station);
+    ChargingStation persisted = repository.save(station);
+
+    if (!resolvedStatus.equals(previousStatus)) {
+      eventPublisher.publishEvent(
+          new StationStatusChangedEvent(
+              persisted.getStationId(),
+              persisted.getStatus(),
+              previousStatus,
+              persisted.getTenantId(),
+              persisted.getSiteId(),
+              Instant.now()));
+    }
+
+    return persisted;
   }
 
   private String defaultStatus(String status) {

--- a/src/main/java/com/arthexis/platform/config/AdminWebSocketConfig.java
+++ b/src/main/java/com/arthexis/platform/config/AdminWebSocketConfig.java
@@ -1,0 +1,61 @@
+package com.arthexis.platform.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class AdminWebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    registry.enableSimpleBroker("/topic/admin");
+    registry.setApplicationDestinationPrefixes("/app");
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws/admin").setAllowedOriginPatterns("*");
+  }
+
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    registration.interceptors(
+        new ChannelInterceptor() {
+          @Override
+          public Message<?> preSend(Message<?> message, org.springframework.messaging.MessageChannel channel) {
+            StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+            if (accessor.getCommand() != StompCommand.SUBSCRIBE
+                && accessor.getCommand() != StompCommand.SEND
+                && accessor.getCommand() != StompCommand.CONNECT) {
+              return message;
+            }
+
+            Authentication authentication = (Authentication) accessor.getUser();
+            if (authentication == null || !authentication.isAuthenticated()) {
+              throw new SecurityException("Authentication required for admin websocket channel");
+            }
+
+            boolean authorized =
+                authentication.getAuthorities().stream()
+                    .anyMatch(
+                        grantedAuthority ->
+                            "ROLE_ADMIN".equals(grantedAuthority.getAuthority())
+                                || "ROLE_OPERATOR".equals(grantedAuthority.getAuthority()));
+            if (!authorized) {
+              throw new SecurityException("Admin or operator role required for admin websocket channel");
+            }
+            return message;
+          }
+        });
+  }
+}

--- a/src/main/java/com/arthexis/platform/ocpp/OcppSessionAuditService.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppSessionAuditService.java
@@ -1,9 +1,13 @@
 package com.arthexis.platform.ocpp;
 
+import com.arthexis.platform.app.admin.ConnectorChangedEvent;
+import com.arthexis.platform.app.admin.OcppMessagePersistedEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,14 +18,17 @@ public class OcppSessionAuditService {
   private final OcppSessionRecordRepository sessionRepository;
   private final OcppMessageRecordRepository messageRepository;
   private final ObjectMapper objectMapper;
+  private final ApplicationEventPublisher eventPublisher;
 
   public OcppSessionAuditService(
       OcppSessionRecordRepository sessionRepository,
       OcppMessageRecordRepository messageRepository,
-      ObjectMapper objectMapper) {
+      ObjectMapper objectMapper,
+      ApplicationEventPublisher eventPublisher) {
     this.sessionRepository = sessionRepository;
     this.messageRepository = messageRepository;
     this.objectMapper = objectMapper;
+    this.eventPublisher = eventPublisher;
   }
 
   public void markSessionConnected(String sessionId) {
@@ -58,6 +65,10 @@ public class OcppSessionAuditService {
         rawPayload,
         "PARSED",
         null);
+
+    if ("StatusNotification".equals(incoming.action())) {
+      publishConnectorChanged(stationId, incoming.payload());
+    }
   }
 
   public void recordIncomingParseFailure(String sessionId, String rawPayload) {
@@ -126,6 +137,71 @@ public class OcppSessionAuditService {
             resultStatus,
             now,
             now));
+
+    eventPublisher.publishEvent(
+        new OcppMessagePersistedEvent(
+            session.getStationId(),
+            sessionId,
+            direction,
+            action,
+            parseStatus,
+            resultStatus,
+            now));
+  }
+
+  private void publishConnectorChanged(String stationId, Object payload) {
+    if (!(payload instanceof Map<?, ?> rawMap)) {
+      return;
+    }
+    @SuppressWarnings("unchecked")
+    Map<String, Object> map = (Map<String, Object>) rawMap;
+    Map<String, Object> evse = mapValue(map.get("evse"));
+
+    eventPublisher.publishEvent(
+        new ConnectorChangedEvent(
+            stationId,
+            intValue(firstNonNull(evse.get("id"), map.get("evseId"))),
+            intValue(firstNonNull(evse.get("connectorId"), map.get("connectorId"), map.get("connector"))),
+            stringValue(firstNonNull(map.get("status"), map.get("connectorStatus"))),
+            stringValue(map.get("connectorType")),
+            stringValue(firstNonNull(map.get("availability"), map.get("connectorAvailability"))),
+            Instant.now()));
+  }
+
+  private Map<String, Object> mapValue(Object value) {
+    if (value instanceof Map<?, ?> rawMap) {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> casted = (Map<String, Object>) rawMap;
+      return casted;
+    }
+    return Map.of();
+  }
+
+  private Integer intValue(Object value) {
+    if (value instanceof Number number) {
+      return number.intValue();
+    }
+    if (value == null) {
+      return null;
+    }
+    try {
+      return Integer.parseInt(value.toString());
+    } catch (NumberFormatException ex) {
+      return null;
+    }
+  }
+
+  private String stringValue(Object value) {
+    return value == null ? null : value.toString();
+  }
+
+  private Object firstNonNull(Object... values) {
+    for (Object value : values) {
+      if (value != null) {
+        return value;
+      }
+    }
+    return null;
   }
 
   private String payloadToString(Object payload) {

--- a/src/main/java/com/arthexis/platform/security/SecurityConfig.java
+++ b/src/main/java/com/arthexis/platform/security/SecurityConfig.java
@@ -18,6 +18,8 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/actuator/health/**", "/actuator/info")
                     .permitAll()
+                    .requestMatchers("/ws/admin/**")
+                    .hasAnyRole("ADMIN", "OPERATOR")
                     .anyRequest()
                     .authenticated())
         .httpBasic(Customizer.withDefaults());

--- a/src/main/java/com/arthexis/platform/telemetry/TelemetryIngestionService.java
+++ b/src/main/java/com/arthexis/platform/telemetry/TelemetryIngestionService.java
@@ -1,9 +1,11 @@
 package com.arthexis.platform.telemetry;
 
+import com.arthexis.platform.app.admin.TelemetrySummaryEvent;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,9 +15,12 @@ public class TelemetryIngestionService {
   public static final String STRUCTURED_SAMPLES_KEY = "_structuredSamples";
 
   private final TelemetrySampleRepository repository;
+  private final ApplicationEventPublisher eventPublisher;
 
-  public TelemetryIngestionService(TelemetrySampleRepository repository) {
+  public TelemetryIngestionService(
+      TelemetrySampleRepository repository, ApplicationEventPublisher eventPublisher) {
     this.repository = repository;
+    this.eventPublisher = eventPublisher;
   }
 
   @Transactional
@@ -25,17 +30,29 @@ public class TelemetryIngestionService {
 
     structuredSamples.forEach(sample -> repository.save(buildSample(stationId, sample, defaultSampledAt)));
 
-    payload.entrySet().stream()
-        .filter(entry -> entry.getValue() instanceof Number)
-        .filter(entry -> !"stationId".equals(entry.getKey()))
-        .forEach(
-            entry ->
-                repository.save(
-                    new TelemetrySample(
-                        stationId,
-                        entry.getKey(),
-                        ((Number) entry.getValue()).doubleValue(),
-                        defaultSampledAt)));
+    int numericPayloadSamples =
+        (int)
+            payload.entrySet().stream()
+                .filter(entry -> entry.getValue() instanceof Number)
+                .filter(entry -> !"stationId".equals(entry.getKey()))
+                .peek(
+                    entry ->
+                        repository.save(
+                            new TelemetrySample(
+                                stationId,
+                                entry.getKey(),
+                                ((Number) entry.getValue()).doubleValue(),
+                                defaultSampledAt)))
+                .count();
+
+    eventPublisher.publishEvent(
+        new TelemetrySummaryEvent(
+            stationId,
+            structuredSamples.size() + numericPayloadSamples,
+            structuredSamples.size(),
+            numericPayloadSamples,
+            defaultSampledAt,
+            Instant.now()));
   }
 
   private TelemetrySample buildSample(

--- a/src/test/java/com/arthexis/platform/charging/ChargingStationServiceTests.java
+++ b/src/test/java/com/arthexis/platform/charging/ChargingStationServiceTests.java
@@ -12,17 +12,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class ChargingStationServiceTests {
 
   @Mock private ChargingStationRepository repository;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   private ChargingStationService service;
 
   @BeforeEach
   void setUp() {
-    service = new ChargingStationService(repository);
+    service = new ChargingStationService(repository, eventPublisher);
   }
 
   @Test

--- a/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeStatusNotificationTests.java
+++ b/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeStatusNotificationTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,6 +31,7 @@ class OcaOcppBridgeStatusNotificationTests {
   @Mock private ChargingStationRepository chargingStationRepository;
   @Mock private ChargingConnectorStateRepository connectorStateRepository;
   @Mock private TelemetrySampleRepository telemetrySampleRepository;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   private OcaOcppBridgeService bridgeService;
 
@@ -37,10 +39,10 @@ class OcaOcppBridgeStatusNotificationTests {
   void setUp() {
     bridgeService =
         new OcaOcppBridgeService(
-            new ChargingStationService(chargingStationRepository),
+            new ChargingStationService(chargingStationRepository, eventPublisher),
             new ChargingConnectorStateService(connectorStateRepository),
             new OcppSessionStateStore(new StringRedisTemplate()),
-            new TelemetryIngestionService(telemetrySampleRepository),
+            new TelemetryIngestionService(telemetrySampleRepository, eventPublisher),
             new OcaOcppPayloadNormalizer());
   }
 


### PR DESCRIPTION
### Motivation

- Provide a dedicated admin realtime stream separate from the raw OCPP socket so admin/operator clients can subscribe to station status, connector changes, session events and telemetry summaries.
- Emit domain events where status/telemetry/session changes occur and translate them to admin websocket payloads for fan-out.
- Ensure only authorized users can open/subscribe/send on the admin websocket channel by enforcing role checks during HTTP upgrade and inbound STOMP processing.

### Description

- Added a new Modulith named interface `com.arthexis.platform.app.admin` and a set of admin domain event records and an `AdminRealtimePayload` DTO under `src/main/java/com/arthexis/platform/app/admin` to model admin events.
- Implemented `AdminWebSocketConfig` to expose a STOMP endpoint at `/ws/admin`, enable a simple broker under `/topic/admin`, and enforce inbound STOMP `CONNECT`/`SUBSCRIBE`/`SEND` authorization via a `ChannelInterceptor` that requires `ROLE_ADMIN` or `ROLE_OPERATOR`.
- Added `AdminWebSocketDomainEventBridge` to convert published domain events into admin realtime payloads and publish them to `/topic/admin/events`, and `AdminWebSocketCommandController` to accept admin-side commands at `/app/admin/commands` and relay them as audit events.
- Instrumented domain layers to publish events: `ChargingStationService` now emits `StationStatusChangedEvent` on status transitions, `TelemetryIngestionService` publishes `TelemetrySummaryEvent` per ingest batch, and `OcppSessionAuditService` publishes `OcppMessagePersistedEvent` on message persistence and emits `ConnectorChangedEvent` when parsing `StatusNotification`.
- Secured admin websocket handshake by requiring `hasAnyRole("ADMIN","OPERATOR")` for `/ws/admin/**` in `SecurityConfig` and exposed the admin package to satisfy modulith boundary checks; updated affected unit tests to inject `ApplicationEventPublisher` mocks.

### Testing

- Ran targeted unit tests with `mvn -q -Dtest=ChargingStationServiceTests,TelemetryIngestionServiceTests,OcaOcppBridgeStatusNotificationTests,ModularityTests test` and they passed.
- Ran `spotless:check` locally but it fails in this environment due to a `google-java-format` / JDK API incompatibility (a formatter plugin `NoSuchMethodError`) unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc19c7675c83268e83db524b468e98)