### PR TITLE
ci: drop Ubuntu 22.04 (jammy) from rpi-compat matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,17 +115,11 @@ jobs:
           - distro: debian-bookworm
             image: maven:3.9.9-eclipse-temurin-21
             install_mode: new-install
-          - distro: ubuntu-jammy
-            image: maven:3.9.9-eclipse-temurin-21-jammy
-            install_mode: new-install
           - distro: ubuntu-noble
             image: maven:3.9.9-eclipse-temurin-21-noble
             install_mode: new-install
           - distro: debian-bookworm-upgrade
             image: maven:3.9.9-eclipse-temurin-21
-            install_mode: upgrade-install
-          - distro: ubuntu-jammy-upgrade
-            image: maven:3.9.9-eclipse-temurin-21-jammy
             install_mode: upgrade-install
           - distro: ubuntu-noble-upgrade
             image: maven:3.9.9-eclipse-temurin-21-noble


### PR DESCRIPTION
### Motivation
- Remove Ubuntu 22.04 (Jammy) entries from the `rpi-compat` GitHub Actions matrix to stop running Jammy-based jobs while keeping `debian-bookworm` and `ubuntu-noble` coverage.

### Description
- Deleted the `ubuntu-jammy` and `ubuntu-jammy-upgrade` `include` entries in `.github/workflows/ci.yml`, so the `rpi-compat` matrix no longer launches Jammy images (workflow file: `.github/workflows/ci.yml`).

### Testing
- No automated tests were executed for this workflow-only change; CI behavior will be observed when GitHub Actions runs the updated workflow on subsequent PRs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc56ef96708326b02e5b5d62bcbc01)