### PR TITLE
Add CI job to capture admin and user UI screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,3 +227,52 @@ jobs:
         run: |
           echo "RPI compatibility verification failed for: ${{ matrix.distro }} / ${{ matrix.install_mode }}"
           exit 1
+
+  ui-screenshots:
+    name: ui-screenshots
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Chromium for Playwright
+        run: npx --yes -p playwright@1.53.0 playwright install --with-deps chromium
+      - name: Capture admin and user UI screenshots
+        run: |
+          mkdir -p artifacts/screenshots
+          npx --yes -p playwright@1.53.0 node <<'EOF_NODE'
+          const { chromium } = require('playwright');
+          const path = require('node:path');
+
+          (async () => {
+            const browser = await chromium.launch();
+            const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+
+            const captures = [
+              {
+                input: path.resolve('src/main/resources/static/admin/index.html'),
+                output: path.resolve('artifacts/screenshots/admin-ui.png')
+              },
+              {
+                input: path.resolve('src/main/resources/static/cp/index.html'),
+                output: path.resolve('artifacts/screenshots/user-ui.png')
+              }
+            ];
+
+            for (const capture of captures) {
+              await page.goto(`file://${capture.input}`);
+              await page.screenshot({ path: capture.output, fullPage: true });
+            }
+
+            await browser.close();
+          })();
+          EOF_NODE
+      - name: Upload UI screenshots artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-screenshots
+          path: artifacts/screenshots


### PR DESCRIPTION
### Motivation
- Provide a simple CI job that captures the current render of the admin and user web UIs so artifacts are available for visual inspection and basic regression detection.
- Keep the job isolated from the build/test matrix so screenshots can be produced independently on demand.

### Description
- Added a new `ui-screenshots` job to `.github/workflows/ci.yml` that runs on `ubuntu-latest` and checks out the repository. 
- The job sets up Node.js (`node-version: 20`) and installs Chromium via Playwright using `npx --yes -p playwright@1.53.0 playwright install --with-deps chromium`.
- An inline Node/Playwright script opens `file://` pages for `src/main/resources/static/admin/index.html` and `src/main/resources/static/cp/index.html` and writes `admin-ui.png` and `user-ui.png` to `artifacts/screenshots`.
- The generated screenshots are uploaded using `actions/upload-artifact@v4` with the artifact name `ui-screenshots`.

### Testing
- No automated tests were executed as part of this change because the modification only adds a CI workflow file; the workflow itself will run in GitHub Actions once pushed and can be validated there.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc60a518d883268392e7ae1480cec0)