### PR TITLE
Add legacy OCPP Start/StopTransaction and Configuration handlers with normalizer, fixtures and tests

### DIFF
--- a/docs/ocpp/compatibility-spec.md
+++ b/docs/ocpp/compatibility-spec.md
@@ -12,6 +12,10 @@ Supported incoming actions:
 - `MeterValues`
 - `TransactionEvent`
 - `Authorize`
+- `StartTransaction`
+- `StopTransaction`
+- `ChangeConfiguration`
+- `GetConfiguration`
 - `DiagnosticsStatusNotification`
 - `FirmwareStatusNotification`
 - `AvailabilityStatusNotification`
@@ -95,6 +99,54 @@ Normalizer output contract for `Authorize`:
 - Includes `idToken` and/or `idTag` when present.
 - Includes `certificateStatus` when present.
 
+### StartTransaction
+
+| Variant | Required fields accepted | Optional fields accepted | Notes |
+|---|---|---|---|
+| 1.6J | none for parser entry; connector + token recommended | `stationId`, `connectorId`, `idTag`, `meterStart`, `timestamp`, `transactionId` | Normalizer extracts legacy transaction start fields for bridge status/state updates. |
+| 2.x compatibility | none | `chargingStation.serialNumber`, `connectorId`, `idTag`, `timestamp` | Treated as compatibility pathway for legacy test suites that still emit start semantics. |
+
+Normalizer output contract for start transaction:
+
+- Always includes `stationId`.
+- Includes numeric `connectorId` / `meterStart` when present.
+- Includes string `idTag`, `timestamp`, and `transactionId` when present.
+
+### StopTransaction
+
+| Variant | Required fields accepted | Optional fields accepted | Notes |
+|---|---|---|---|
+| 1.6J | none for parser entry; connector + transaction recommended | `stationId`, `connectorId`, `idTag`, `meterStop`, `timestamp`, `transactionId`, `reason` | Used for explicit end-of-session lifecycle parity with legacy clients. |
+| 2.x compatibility | none | `chargingStation.serialNumber`, `connectorId`, `transactionId`, `reason` | Compatibility mapping supported when stop event payloads are emitted in mixed environments. |
+
+Normalizer output contract for stop transaction:
+
+- Always includes `stationId`.
+- Includes numeric `connectorId` / `meterStop` when present.
+- Includes string `idTag`, `timestamp`, `transactionId`, and `reason` when present.
+
+### ChangeConfiguration
+
+| Variant | Required fields accepted | Optional fields accepted | Notes |
+|---|---|---|---|
+| 1.6J | none for parser entry; key/value recommended | `stationId`, `key`, `value` | Supported for production parity workflows where legacy clients post configuration updates. |
+
+Normalizer output contract for change configuration:
+
+- Always includes `stationId`.
+- Includes `key` and `value` as strings when present.
+
+### GetConfiguration
+
+| Variant | Required fields accepted | Optional fields accepted | Notes |
+|---|---|---|---|
+| 1.6J | none for parser entry; key list optional | `stationId`, `key[]` | Bridge response includes `configurationKey[]` and `unknownKey[]` placeholders for compatibility tests. |
+
+Normalizer output contract for get configuration:
+
+- Always includes `stationId`.
+- Includes `key` list when present.
+
 ### DiagnosticsStatusNotification
 
 | Variant | Required fields accepted | Optional fields accepted | Notes |
@@ -167,5 +219,9 @@ Included fixture files:
 - `diagnostics_status.ocpp16.json`
 - `firmware_status.ocpp2x.json`
 - `availability_status.ocpp2x.json`
+- `start_transaction.ocpp16.json`
+- `stop_transaction.ocpp16.json`
+- `change_configuration.ocpp16.json`
+- `get_configuration.ocpp16.json`
 
 These fixtures are the contract-test inputs for backward compatibility assertions in `OcaOcppPayloadNormalizerContractTests`.

--- a/docs/ocpp/fixtures/change_configuration.ocpp16.json
+++ b/docs/ocpp/fixtures/change_configuration.ocpp16.json
@@ -1,0 +1,24 @@
+{
+  "name": "change_configuration_ocpp16_legacy",
+  "action": "ChangeConfiguration",
+  "ocppVariant": "1.6J",
+  "sessionId": "session-change-config-16",
+  "payload": {
+    "stationId": "CP-16-CFG",
+    "key": "HeartbeatInterval",
+    "value": "60"
+  },
+  "expected": {
+    "resolvedStationId": "CP-16-CFG",
+    "normalized": {
+      "stationId": "CP-16-CFG",
+      "key": "HeartbeatInterval",
+      "value": "60"
+    },
+    "types": {
+      "stationId": "string",
+      "key": "string",
+      "value": "string"
+    }
+  }
+}

--- a/docs/ocpp/fixtures/get_configuration.ocpp16.json
+++ b/docs/ocpp/fixtures/get_configuration.ocpp16.json
@@ -1,0 +1,26 @@
+{
+  "name": "get_configuration_ocpp16_legacy",
+  "action": "GetConfiguration",
+  "ocppVariant": "1.6J",
+  "sessionId": "session-get-config-16",
+  "payload": {
+    "stationId": "CP-16-CFG",
+    "key": [
+      "HeartbeatInterval",
+      "MeterValueSampleInterval"
+    ]
+  },
+  "expected": {
+    "resolvedStationId": "CP-16-CFG",
+    "normalized": {
+      "stationId": "CP-16-CFG",
+      "key": [
+        "HeartbeatInterval",
+        "MeterValueSampleInterval"
+      ]
+    },
+    "types": {
+      "stationId": "string"
+    }
+  }
+}

--- a/docs/ocpp/fixtures/start_transaction.ocpp16.json
+++ b/docs/ocpp/fixtures/start_transaction.ocpp16.json
@@ -1,0 +1,33 @@
+{
+  "name": "start_transaction_ocpp16_legacy",
+  "action": "StartTransaction",
+  "ocppVariant": "1.6J",
+  "sessionId": "session-start-16",
+  "payload": {
+    "stationId": "CP-16-START",
+    "connectorId": 2,
+    "idTag": "CARD-16",
+    "meterStart": 1050,
+    "timestamp": "2026-03-31T01:10:00Z",
+    "transactionId": 88
+  },
+  "expected": {
+    "resolvedStationId": "CP-16-START",
+    "normalized": {
+      "stationId": "CP-16-START",
+      "connectorId": 2,
+      "idTag": "CARD-16",
+      "meterStart": 1050,
+      "timestamp": "2026-03-31T01:10:00Z",
+      "transactionId": "88"
+    },
+    "types": {
+      "stationId": "string",
+      "connectorId": "number",
+      "idTag": "string",
+      "meterStart": "number",
+      "timestamp": "string",
+      "transactionId": "string"
+    }
+  }
+}

--- a/docs/ocpp/fixtures/stop_transaction.ocpp16.json
+++ b/docs/ocpp/fixtures/stop_transaction.ocpp16.json
@@ -1,0 +1,36 @@
+{
+  "name": "stop_transaction_ocpp16_legacy",
+  "action": "StopTransaction",
+  "ocppVariant": "1.6J",
+  "sessionId": "session-stop-16",
+  "payload": {
+    "stationId": "CP-16-STOP",
+    "connectorId": 2,
+    "idTag": "CARD-16",
+    "meterStop": 1150,
+    "timestamp": "2026-03-31T02:10:00Z",
+    "transactionId": 88,
+    "reason": "Local"
+  },
+  "expected": {
+    "resolvedStationId": "CP-16-STOP",
+    "normalized": {
+      "stationId": "CP-16-STOP",
+      "connectorId": 2,
+      "idTag": "CARD-16",
+      "meterStop": 1150,
+      "timestamp": "2026-03-31T02:10:00Z",
+      "transactionId": "88",
+      "reason": "Local"
+    },
+    "types": {
+      "stationId": "string",
+      "connectorId": "number",
+      "idTag": "string",
+      "meterStop": "number",
+      "timestamp": "string",
+      "transactionId": "string",
+      "reason": "string"
+    }
+  }
+}

--- a/src/main/java/com/arthexis/platform/ocpp/OcaOcppBridgeService.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcaOcppBridgeService.java
@@ -7,6 +7,8 @@ import com.arthexis.platform.charging.ChargingStationAdminDetails;
 import com.arthexis.platform.charging.ChargingStationService;
 import com.arthexis.platform.telemetry.TelemetryIngestionService;
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
@@ -101,6 +103,48 @@ public class OcaOcppBridgeService {
           chargingStationService.upsertStatus(stationId, "AVAILABLE");
         }
         yield response(stationId, accepted());
+      }
+      case "StartTransaction" -> {
+        Map<String, Object> normalized = payloadNormalizer.normalizeStartTransaction(stationId, payload);
+        int connectorId = intValue(normalized.get("connectorId"), 1);
+        connectorStateService.upsertConnectorState(
+            stationId, 1, connectorId, "CHARGING", "", "Operative", Instant.now());
+        chargingStationService.upsertStatus(stationId, "CHARGING", buildAdminDetails(payload, false));
+        yield response(
+            stationId,
+            Map.of(
+                "idTagInfo",
+                Map.of("status", "Accepted"),
+                "transactionId",
+                intValue(normalized.get("transactionId"), 1)));
+      }
+      case "StopTransaction" -> {
+        Map<String, Object> normalized = payloadNormalizer.normalizeStopTransaction(stationId, payload);
+        int connectorId = intValue(normalized.get("connectorId"), 1);
+        connectorStateService.upsertConnectorState(
+            stationId, 1, connectorId, "AVAILABLE", "", "Operative", Instant.now());
+        chargingStationService.upsertStatus(stationId, "AVAILABLE", buildAdminDetails(payload, false));
+        yield response(stationId, Map.of("idTagInfo", Map.of("status", "Accepted")));
+      }
+      case "ChangeConfiguration" -> {
+        Map<String, Object> normalized =
+            payloadNormalizer.normalizeChangeConfiguration(stationId, payload);
+        chargingStationService.upsertStatus(stationId, "ONLINE", buildAdminDetails(payload, false));
+        stateStore.storePendingCommand(stationId, incoming.messageId(), incoming.action());
+        yield response(
+            stationId,
+            Map.of("status", "Accepted", "key", stringValue(normalized.get("key"))));
+      }
+      case "GetConfiguration" -> {
+        Map<String, Object> normalized = payloadNormalizer.normalizeGetConfiguration(stationId, payload);
+        chargingStationService.upsertStatus(stationId, "ONLINE", buildAdminDetails(payload, false));
+        yield response(
+            stationId,
+            Map.of(
+                "configurationKey",
+                mapConfigurationKeys(normalized.get("key")),
+                "unknownKey",
+                List.of()));
       }
       case "DiagnosticsStatusNotification" -> {
         chargingStationService.upsertStatus(stationId, "ONLINE", buildAdminDetails(payload, false));
@@ -305,5 +349,20 @@ public class OcaOcppBridgeService {
 
   private Map<String, Object> accepted() {
     return Map.of("status", "Accepted");
+  }
+
+  private List<Map<String, Object>> mapConfigurationKeys(Object keys) {
+    if (!(keys instanceof List<?> list) || list.isEmpty()) {
+      return List.of();
+    }
+    return list.stream()
+        .map(
+            value -> {
+              Map<String, Object> configuration = new LinkedHashMap<>();
+              configuration.put("key", stringValue(value));
+              configuration.put("readonly", false);
+              return configuration;
+            })
+        .toList();
   }
 }

--- a/src/main/java/com/arthexis/platform/ocpp/OcaOcppPayloadNormalizer.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcaOcppPayloadNormalizer.java
@@ -141,6 +141,50 @@ public class OcaOcppPayloadNormalizer {
     return normalized;
   }
 
+  public Map<String, Object> normalizeStartTransaction(
+      String stationId, Map<String, Object> payload) {
+    Map<String, Object> normalized = new LinkedHashMap<>();
+    normalized.put("stationId", stationId);
+    copyIfPresent(normalized, payload, "idTag");
+    copyIfPresent(normalized, payload, "transactionId");
+    copyIfPresent(normalized, payload, "timestamp");
+    copyNumericIfPresent(normalized, payload, "connectorId");
+    copyNumericIfPresent(normalized, payload, "meterStart");
+    return normalized;
+  }
+
+  public Map<String, Object> normalizeStopTransaction(String stationId, Map<String, Object> payload) {
+    Map<String, Object> normalized = new LinkedHashMap<>();
+    normalized.put("stationId", stationId);
+    copyIfPresent(normalized, payload, "idTag");
+    copyIfPresent(normalized, payload, "transactionId");
+    copyIfPresent(normalized, payload, "timestamp");
+    copyNumericIfPresent(normalized, payload, "connectorId");
+    copyNumericIfPresent(normalized, payload, "meterStop");
+    copyIfPresent(normalized, payload, "reason");
+    return normalized;
+  }
+
+  public Map<String, Object> normalizeChangeConfiguration(
+      String stationId, Map<String, Object> payload) {
+    Map<String, Object> normalized = new LinkedHashMap<>();
+    normalized.put("stationId", stationId);
+    copyIfPresent(normalized, payload, "key");
+    copyIfPresent(normalized, payload, "value");
+    return normalized;
+  }
+
+  public Map<String, Object> normalizeGetConfiguration(
+      String stationId, Map<String, Object> payload) {
+    Map<String, Object> normalized = new LinkedHashMap<>();
+    normalized.put("stationId", stationId);
+    Object keys = payload.get("key");
+    if (keys instanceof List<?> list) {
+      normalized.put("key", List.copyOf(list));
+    }
+    return normalized;
+  }
+
   private NormalizedSampleExtraction extractSampledValues(Map<String, Object> payload) {
     Map<String, Object> flattened = new LinkedHashMap<>();
     List<Map<String, Object>> structuredSamples = new ArrayList<>();
@@ -223,6 +267,27 @@ public class OcaOcppPayloadNormalizer {
     if (!value.isBlank()) {
       target.put(key, value);
     }
+  }
+
+  private void copyNumericIfPresent(Map<String, Object> target, Map<String, Object> source, String key) {
+    Integer value = parseInteger(source.get(key));
+    if (value != null) {
+      target.put(key, value);
+    }
+  }
+
+  private Integer parseInteger(Object rawValue) {
+    if (rawValue instanceof Number number) {
+      return number.intValue();
+    }
+    if (rawValue instanceof String text) {
+      try {
+        return Integer.parseInt(text);
+      } catch (NumberFormatException ignored) {
+        return null;
+      }
+    }
+    return null;
   }
 
   private String resolveScopeType(String connectorId, String evseId, String transactionId) {

--- a/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeServiceTests.java
+++ b/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeServiceTests.java
@@ -1,6 +1,9 @@
 package com.arthexis.platform.ocpp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.arthexis.platform.auth.AuthorizationDecision;
@@ -209,5 +212,88 @@ class OcaOcppBridgeServiceTests {
             new OcppMessage("2", "msg-auth-missing", "Authorize", Map.of("stationId", "CP-16")));
 
     assertThat(response.payload()).isEqualTo(Map.of("idTagInfo", Map.of("status", "Invalid")));
+  }
+
+  @Test
+  void startTransactionLegacyActionUpdatesConnectorAndStationState() {
+    OcppBridgeResponse response =
+        bridgeService.handleIncoming(
+            "session-start",
+            new OcppMessage(
+                "2",
+                "msg-start-16",
+                "StartTransaction",
+                Map.of(
+                    "stationId",
+                    "CP-16",
+                    "connectorId",
+                    2,
+                    "idTag",
+                    "CARD-16",
+                    "meterStart",
+                    100,
+                    "transactionId",
+                    55)));
+
+    verify(connectorStateService)
+        .upsertConnectorState(eq("CP-16"), eq(1), eq(2), eq("CHARGING"), eq(""), eq("Operative"), any());
+    verify(chargingStationService).upsertStatus(eq("CP-16"), eq("CHARGING"), any());
+    assertThat(response.payload())
+        .isEqualTo(Map.of("idTagInfo", Map.of("status", "Accepted"), "transactionId", 55));
+  }
+
+  @Test
+  void stopTransactionLegacyActionUpdatesConnectorAndStationState() {
+    OcppBridgeResponse response =
+        bridgeService.handleIncoming(
+            "session-stop",
+            new OcppMessage(
+                "2",
+                "msg-stop-16",
+                "StopTransaction",
+                Map.of("stationId", "CP-16", "connectorId", 2, "meterStop", 125, "transactionId", 55)));
+
+    verify(connectorStateService)
+        .upsertConnectorState(eq("CP-16"), eq(1), eq(2), eq("AVAILABLE"), eq(""), eq("Operative"), any());
+    verify(chargingStationService).upsertStatus(eq("CP-16"), eq("AVAILABLE"), any());
+    assertThat(response.payload()).isEqualTo(Map.of("idTagInfo", Map.of("status", "Accepted")));
+  }
+
+  @Test
+  void changeConfigurationStoresPendingCommandAndReturnsAccepted() {
+    OcppBridgeResponse response =
+        bridgeService.handleIncoming(
+            "session-cfg",
+            new OcppMessage(
+                "2",
+                "msg-change-cfg",
+                "ChangeConfiguration",
+                Map.of("stationId", "CP-16", "key", "HeartbeatInterval", "value", "120")));
+
+    verify(chargingStationService).upsertStatus(eq("CP-16"), eq("ONLINE"), any());
+    verify(stateStore).storePendingCommand("CP-16", "msg-change-cfg", "ChangeConfiguration");
+    assertThat(response.payload())
+        .isEqualTo(Map.of("status", "Accepted", "key", "HeartbeatInterval"));
+  }
+
+  @Test
+  void getConfigurationReturnsCompatibilityShape() {
+    OcppBridgeResponse response =
+        bridgeService.handleIncoming(
+            "session-cfg",
+            new OcppMessage(
+                "2",
+                "msg-get-cfg",
+                "GetConfiguration",
+                Map.of("stationId", "CP-16", "key", List.of("HeartbeatInterval"))));
+
+    verify(chargingStationService).upsertStatus(eq("CP-16"), eq("ONLINE"), any());
+    assertThat(response.payload())
+        .isEqualTo(
+            Map.of(
+                "configurationKey",
+                List.of(Map.of("key", "HeartbeatInterval", "readonly", false)),
+                "unknownKey",
+                List.of()));
   }
 }

--- a/src/test/java/com/arthexis/platform/ocpp/OcaOcppPayloadNormalizerContractTests.java
+++ b/src/test/java/com/arthexis/platform/ocpp/OcaOcppPayloadNormalizerContractTests.java
@@ -120,6 +120,62 @@ class OcaOcppPayloadNormalizerContractTests {
     assertNormalizationMatchesContract(normalized, expected);
   }
 
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("startTransactionFixtures")
+  void keepsStartTransactionNormalizationContractBackwardCompatible(String fixtureFile)
+      throws IOException {
+    Map<String, Object> fixture = readFixture(fixtureFile);
+    Map<String, Object> payload = mapValue(fixture.get("payload"));
+    Map<String, Object> expected = mapValue(fixture.get("expected"));
+
+    String stationId = normalizer.resolveStationId(stringValue(fixture.get("sessionId")), payload);
+    Map<String, Object> normalized = normalizer.normalizeStartTransaction(stationId, payload);
+
+    assertNormalizationMatchesContract(normalized, expected);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("stopTransactionFixtures")
+  void keepsStopTransactionNormalizationContractBackwardCompatible(String fixtureFile)
+      throws IOException {
+    Map<String, Object> fixture = readFixture(fixtureFile);
+    Map<String, Object> payload = mapValue(fixture.get("payload"));
+    Map<String, Object> expected = mapValue(fixture.get("expected"));
+
+    String stationId = normalizer.resolveStationId(stringValue(fixture.get("sessionId")), payload);
+    Map<String, Object> normalized = normalizer.normalizeStopTransaction(stationId, payload);
+
+    assertNormalizationMatchesContract(normalized, expected);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("changeConfigurationFixtures")
+  void keepsChangeConfigurationNormalizationContractBackwardCompatible(String fixtureFile)
+      throws IOException {
+    Map<String, Object> fixture = readFixture(fixtureFile);
+    Map<String, Object> payload = mapValue(fixture.get("payload"));
+    Map<String, Object> expected = mapValue(fixture.get("expected"));
+
+    String stationId = normalizer.resolveStationId(stringValue(fixture.get("sessionId")), payload);
+    Map<String, Object> normalized = normalizer.normalizeChangeConfiguration(stationId, payload);
+
+    assertNormalizationMatchesContract(normalized, expected);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("getConfigurationFixtures")
+  void keepsGetConfigurationNormalizationContractBackwardCompatible(String fixtureFile)
+      throws IOException {
+    Map<String, Object> fixture = readFixture(fixtureFile);
+    Map<String, Object> payload = mapValue(fixture.get("payload"));
+    Map<String, Object> expected = mapValue(fixture.get("expected"));
+
+    String stationId = normalizer.resolveStationId(stringValue(fixture.get("sessionId")), payload);
+    Map<String, Object> normalized = normalizer.normalizeGetConfiguration(stationId, payload);
+
+    assertNormalizationMatchesContract(normalized, expected);
+  }
+
   private static Stream<Arguments> fixtureFiles() {
     return Stream.of(
             "boot_notification.ocpp16.json",
@@ -132,6 +188,10 @@ class OcaOcppPayloadNormalizerContractTests {
             "diagnostics_status.ocpp16.json",
             "firmware_status.ocpp2x.json",
             "availability_status.ocpp2x.json",
+            "start_transaction.ocpp16.json",
+            "stop_transaction.ocpp16.json",
+            "change_configuration.ocpp16.json",
+            "get_configuration.ocpp16.json",
             "meter_values.ocpp16.json",
             "meter_values.ocpp2x.json",
             "transaction_event.ocpp16.json",
@@ -162,6 +222,22 @@ class OcaOcppPayloadNormalizerContractTests {
 
   private static Stream<Arguments> availabilityFixtures() {
     return Stream.of("availability_status.ocpp2x.json").map(Arguments::of);
+  }
+
+  private static Stream<Arguments> startTransactionFixtures() {
+    return Stream.of("start_transaction.ocpp16.json").map(Arguments::of);
+  }
+
+  private static Stream<Arguments> stopTransactionFixtures() {
+    return Stream.of("stop_transaction.ocpp16.json").map(Arguments::of);
+  }
+
+  private static Stream<Arguments> changeConfigurationFixtures() {
+    return Stream.of("change_configuration.ocpp16.json").map(Arguments::of);
+  }
+
+  private static Stream<Arguments> getConfigurationFixtures() {
+    return Stream.of("get_configuration.ocpp16.json").map(Arguments::of);
   }
 
   private static void assertNormalizationMatchesContract(


### PR DESCRIPTION
### Motivation

- Provide explicit compatibility handlers for legacy OCPP transaction semantics and common station lifecycle/configuration operations so bridge behavior matches production parity testing and older clients.

### Description

- Added explicit action handlers in `OcaOcppBridgeService` for `StartTransaction`, `StopTransaction`, `ChangeConfiguration`, and `GetConfiguration` that extract normalized payloads, update connector and station state, and produce compatibility-shaped responses.
- Implemented normalization methods in `OcaOcppPayloadNormalizer` (`normalizeStartTransaction`, `normalizeStopTransaction`, `normalizeChangeConfiguration`, `normalizeGetConfiguration`) plus numeric parsing helpers to produce stable normalized contracts.
- Added canonical fixtures under `docs/ocpp/fixtures` for the new actions and updated `docs/ocpp/compatibility-spec.md` to document the new compatibility pathways and expected normalizer outputs. 
- Extended tests: added contract tests in `OcaOcppPayloadNormalizerContractTests` and bridge behavior tests in `OcaOcppBridgeServiceTests` to validate normalization and state/response behaviors for the new actions. 

### Testing

- Ran the normalization contract and bridge unit tests with `mvn -Dtest=OcaOcppPayloadNormalizerContractTests,OcaOcppBridgeServiceTests test` and the test suite completed successfully. 
- The added parameterized fixtures are exercised by `OcaOcppPayloadNormalizerContractTests` and the new behavior assertions by `OcaOcppBridgeServiceTests` (both passed in the targeted run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2ac175e883268d6d2b3f3d10bec3)