### PR TITLE
Fix legacy transaction connector resolution and transaction IDs

### DIFF
--- a/src/main/java/com/arthexis/platform/ocpp/OcaOcppBridgeService.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcaOcppBridgeService.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -107,8 +108,16 @@ public class OcaOcppBridgeService {
       case "StartTransaction" -> {
         Map<String, Object> normalized = payloadNormalizer.normalizeStartTransaction(stationId, payload);
         int connectorId = intValue(normalized.get("connectorId"), 1);
+        int transactionId = resolveTransactionId(stationId, normalized);
+        stateStore.storeTransactionConnector(stationId, transactionId, connectorId);
         connectorStateService.upsertConnectorState(
-            stationId, 1, connectorId, "CHARGING", "", "Operative", Instant.now());
+            stationId,
+            1,
+            connectorId,
+            "CHARGING",
+            "",
+            "Operative",
+            resolveEventTimestamp(normalized));
         chargingStationService.upsertStatus(stationId, "CHARGING", buildAdminDetails(payload, false));
         yield response(
             stationId,
@@ -116,13 +125,20 @@ public class OcaOcppBridgeService {
                 "idTagInfo",
                 Map.of("status", "Accepted"),
                 "transactionId",
-                intValue(normalized.get("transactionId"), 1)));
+                transactionId));
       }
       case "StopTransaction" -> {
         Map<String, Object> normalized = payloadNormalizer.normalizeStopTransaction(stationId, payload);
-        int connectorId = intValue(normalized.get("connectorId"), 1);
+        int transactionId = intValue(normalized.get("transactionId"), -1);
+        int connectorId = resolveStopConnectorId(stationId, normalized, transactionId);
         connectorStateService.upsertConnectorState(
-            stationId, 1, connectorId, "AVAILABLE", "", "Operative", Instant.now());
+            stationId,
+            1,
+            connectorId,
+            "AVAILABLE",
+            "",
+            "Operative",
+            resolveEventTimestamp(normalized));
         chargingStationService.upsertStatus(stationId, "AVAILABLE", buildAdminDetails(payload, false));
         yield response(stationId, Map.of("idTagInfo", Map.of("status", "Accepted")));
       }
@@ -188,6 +204,29 @@ public class OcaOcppBridgeService {
     Object connectorId =
         firstNonNull(evse.get("connectorId"), payload.get("connectorId"), payload.get("connector"), 1);
     return intValue(connectorId, 1);
+  }
+
+  private int resolveTransactionId(String stationId, Map<String, Object> normalized) {
+    int transactionId = intValue(normalized.get("transactionId"), -1);
+    if (transactionId > 0) {
+      return transactionId;
+    }
+    return stateStore.reserveTransactionId(stationId);
+  }
+
+  private int resolveStopConnectorId(
+      String stationId, Map<String, Object> normalized, int transactionId) {
+    int normalizedConnectorId = intValue(normalized.get("connectorId"), -1);
+    if (normalizedConnectorId > 0) {
+      return normalizedConnectorId;
+    }
+    if (transactionId > 0) {
+      OptionalInt connectorId = stateStore.findTransactionConnector(stationId, transactionId);
+      if (connectorId.isPresent()) {
+        return connectorId.getAsInt();
+      }
+    }
+    return 1;
   }
 
   private ChargingStationAdminDetails buildAdminDetails(

--- a/src/main/java/com/arthexis/platform/ocpp/OcppSessionStateStore.java
+++ b/src/main/java/com/arthexis/platform/ocpp/OcppSessionStateStore.java
@@ -1,6 +1,7 @@
 package com.arthexis.platform.ocpp;
 
 import java.time.Duration;
+import java.util.OptionalInt;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -22,5 +23,37 @@ public class OcppSessionStateStore {
   public void bindStationSession(String stationId, String sessionId) {
     String key = "ocpp:station-session:" + stationId;
     redisTemplate.opsForValue().set(key, sessionId, SESSION_TTL);
+  }
+
+  public int reserveTransactionId(String stationId) {
+    String key = "ocpp:transaction-seq:" + stationId;
+    Long value = redisTemplate.opsForValue().increment(key);
+    redisTemplate.expire(key, SESSION_TTL);
+    if (value == null || value <= 0) {
+      return 1;
+    }
+    return Math.toIntExact(value);
+  }
+
+  public void storeTransactionConnector(String stationId, int transactionId, int connectorId) {
+    String key = transactionConnectorKey(stationId, transactionId);
+    redisTemplate.opsForValue().set(key, Integer.toString(connectorId), SESSION_TTL);
+  }
+
+  public OptionalInt findTransactionConnector(String stationId, int transactionId) {
+    String key = transactionConnectorKey(stationId, transactionId);
+    String value = redisTemplate.opsForValue().get(key);
+    if (value == null || value.isBlank()) {
+      return OptionalInt.empty();
+    }
+    try {
+      return OptionalInt.of(Integer.parseInt(value));
+    } catch (NumberFormatException ignored) {
+      return OptionalInt.empty();
+    }
+  }
+
+  private String transactionConnectorKey(String stationId, int transactionId) {
+    return "ocpp:transaction-connector:" + stationId + ":" + transactionId;
   }
 }

--- a/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeServiceTests.java
+++ b/src/test/java/com/arthexis/platform/ocpp/OcaOcppBridgeServiceTests.java
@@ -3,6 +3,7 @@ package com.arthexis.platform.ocpp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +14,7 @@ import com.arthexis.platform.charging.ChargingStationService;
 import com.arthexis.platform.telemetry.TelemetryIngestionService;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -237,9 +239,30 @@ class OcaOcppBridgeServiceTests {
 
     verify(connectorStateService)
         .upsertConnectorState(eq("CP-16"), eq(1), eq(2), eq("CHARGING"), eq(""), eq("Operative"), any());
+    verify(stateStore).storeTransactionConnector("CP-16", 55, 2);
+    verify(stateStore, never()).reserveTransactionId(any());
     verify(chargingStationService).upsertStatus(eq("CP-16"), eq("CHARGING"), any());
     assertThat(response.payload())
         .isEqualTo(Map.of("idTagInfo", Map.of("status", "Accepted"), "transactionId", 55));
+  }
+
+  @Test
+  void startTransactionWithoutTransactionIdReservesUniqueTransactionId() {
+    when(stateStore.reserveTransactionId("CP-16")).thenReturn(701);
+
+    OcppBridgeResponse response =
+        bridgeService.handleIncoming(
+            "session-start-generated",
+            new OcppMessage(
+                "2",
+                "msg-start-16-generated",
+                "StartTransaction",
+                Map.of("stationId", "CP-16", "connectorId", 2, "idTag", "CARD-16", "meterStart", 100)));
+
+    verify(stateStore).reserveTransactionId("CP-16");
+    verify(stateStore).storeTransactionConnector("CP-16", 701, 2);
+    assertThat(response.payload())
+        .isEqualTo(Map.of("idTagInfo", Map.of("status", "Accepted"), "transactionId", 701));
   }
 
   @Test
@@ -256,6 +279,25 @@ class OcaOcppBridgeServiceTests {
     verify(connectorStateService)
         .upsertConnectorState(eq("CP-16"), eq(1), eq(2), eq("AVAILABLE"), eq(""), eq("Operative"), any());
     verify(chargingStationService).upsertStatus(eq("CP-16"), eq("AVAILABLE"), any());
+    assertThat(response.payload()).isEqualTo(Map.of("idTagInfo", Map.of("status", "Accepted")));
+  }
+
+  @Test
+  void stopTransactionUsesStoredConnectorWhenPayloadOmitsConnectorId() {
+    when(stateStore.findTransactionConnector("CP-16", 55)).thenReturn(OptionalInt.of(2));
+
+    OcppBridgeResponse response =
+        bridgeService.handleIncoming(
+            "session-stop-lookup",
+            new OcppMessage(
+                "2",
+                "msg-stop-16-lookup",
+                "StopTransaction",
+                Map.of("stationId", "CP-16", "meterStop", 125, "transactionId", 55)));
+
+    verify(stateStore).findTransactionConnector("CP-16", 55);
+    verify(connectorStateService)
+        .upsertConnectorState(eq("CP-16"), eq(1), eq(2), eq("AVAILABLE"), eq(""), eq("Operative"), any());
     assertThat(response.payload()).isEqualTo(Map.of("idTagInfo", Map.of("status", "Accepted")));
   }
 


### PR DESCRIPTION
### Motivation

- Address reviewer concerns that `StopTransaction` defaulting to connector `1` breaks multi-connector OCPP 1.6 flows where `connectorId` is often omitted. 
- Replace uses of `Instant.now()` with the event timestamp from normalized payloads to keep connector state time-consistent with station events. 
- Avoid returning a constant fallback `transactionId` from `StartTransaction` to prevent transaction ID collisions.

### Description

- Added Redis-backed helpers to `OcppSessionStateStore` (`reserveTransactionId`, `storeTransactionConnector`, `findTransactionConnector`) to allocate unique transaction IDs and persist transaction→connector mappings. 
- Updated `StartTransaction` handling in `OcaOcppBridgeService` to use `resolveEventTimestamp(normalized)`, reserve a transaction id when missing via `stateStore.reserveTransactionId(...)`, and persist the mapping with `stateStore.storeTransactionConnector(...)`. 
- Updated `StopTransaction` handling in `OcaOcppBridgeService` to resolve the connector id from the stored transaction mapping when `connectorId` is omitted and to use the normalized event timestamp for state updates. 
- Added helper methods `resolveTransactionId(...)` and `resolveStopConnectorId(...)` and expanded bridge unit tests in `OcaOcppBridgeServiceTests` to cover generated transaction IDs, storage of transaction→connector mappings, and connector lookup on stop.

### Testing

- Ran the focused unit tests with `mvn -Dtest=OcaOcppBridgeServiceTests test`. 
- Result: tests passed (`Tests run: 14, Failures: 0, Errors: 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd9fac69d083269a8a8c73e921e44f)